### PR TITLE
fix(ApiRequest): update string request's response parsing to parse with UTF-8 charset (fixes #136)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
@@ -10,8 +10,11 @@ import android.widget.ImageView;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.DefaultRetryPolicy;
+import com.android.volley.NetworkResponse;
 import com.android.volley.RequestQueue;
+import com.android.volley.Response;
 import com.android.volley.VolleyError;
+import com.android.volley.toolbox.HttpHeaderParser;
 import com.android.volley.toolbox.HurlStack;
 import com.android.volley.toolbox.ImageRequest;
 import com.android.volley.toolbox.StringRequest;
@@ -26,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -125,6 +129,12 @@ public abstract class ApiRequest {
             @Override
             public byte[] getBody() throws AuthFailureError {
                 return Optional.fromNullable(requestBody).transform(String::getBytes).orNull();
+            }
+
+            @Override
+            protected Response<String> parseNetworkResponse(NetworkResponse response) {
+                String parsed = new String(response.data, StandardCharsets.UTF_8);
+                return Response.success(parsed, HttpHeaderParser.parseCacheHeaders(response));
             }
         };
 


### PR DESCRIPTION
# Description
fixes #136
After core syncthing removed `charset=utf-8` from api's `Content-Type` response header, the `StringRequest` class from `volley` library fallback to library's default charset `ISO-8859-1` instead of platform default charset `UTF-8` which causes problem in displaying the utf-8 characters used in device name, folder name, etc.

# Changes
- use UTF-8 instead of library default for parsing response bytes to string
