### PR TITLE
feat(docs): Add download section; add obtainium download

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,24 @@ A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android. He
 
 ## Download
 
-[//]: # (Download image provided by)
+[//]: # (Github download image provided by)
 [//]: # (https://github.com/rubenpgrady/get-it-on-github)
-[<img src="https://raw.githubusercontent.com/rubenpgrady/get-it-on-github/refs/heads/main/get-it-on-github.png" alt="Download from GitHub" 
-align="center" height="80" />](https://github.com/researchxxl/syncthing-android/releases)
 
-[//]: # (Download image provided by offical Obtainium repo)
+[//]: # (Obtainum download image provided by offical Obtainium repo)
 [//]: # (https://github.com/ImranR98/Obtainium)
-[<img src="https://github.com/ImranR98/Obtainium/blob/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" 
-align="center" height="80" />](https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/researchxxl/syncthing-android)
 
-[//]: # (Dowload image provided by F-Droid documentation)
+[//]: # (F-droid download image provided by F-Droid documentation)
 [//]: # (https://f-droid.org/docs/Badges/)
-[<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid"
-align="center" height="80">](https://f-droid.org/packages/com.github.catfriend1.syncthingfork)
+
+<a href="https://f-droid.org/packages/com.github.catfriend1.syncthingfork">
+    <img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" align="center" height="80"/>
+</a>
+<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/researchxxl/syncthing-android">
+    <img src="https://github.com/ImranR98/Obtainium/blob/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" align="center" height="60"/>
+</a>
+<a href="https://github.com/researchxxl/syncthing-android/releases">
+    <img src="https://raw.githubusercontent.com/rubenpgrady/get-it-on-github/refs/heads/main/get-it-on-github.png" alt="Download from GitHub" align="center" height="80"/>
+</a>
 
 ## Switching from the deprecated official version
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android. He
 
 <img src="app/src/main/play/listings/en-US/graphics/phone-screenshots/1.png" alt="screenshot 1" width="200" /> · <img src="app/src/main/play/listings/en-US/graphics/phone-screenshots/2.png" alt="screenshot 2" width="200" /> · <img src="app/src/main/play/listings/en-US/graphics/phone-screenshots/4.png" alt="screenshot 3" width="200" />
 
+## Download
+
+[//]: # (Download image provided by)
+[//]: # (https://github.com/rubenpgrady/get-it-on-github)
+[<img src="https://raw.githubusercontent.com/rubenpgrady/get-it-on-github/refs/heads/main/get-it-on-github.png" alt="Download from GitHub" 
+align="center" height="80" />](https://github.com/researchxxl/syncthing-android/releases)
+
+[//]: # (Download image provided by offical Obtainium repo)
+[//]: # (https://github.com/ImranR98/Obtainium)
+[<img src="https://github.com/ImranR98/Obtainium/blob/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" 
+align="center" height="80" />](https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/researchxxl/syncthing-android)
+
+[//]: # (Dowload image provided by F-Droid documentation)
+[//]: # (https://f-droid.org/docs/Badges/)
+[<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid"
+align="center" height="80">](https://f-droid.org/packages/com.github.catfriend1.syncthingfork)
+
 ## Switching from the deprecated official version
 
 Switching is easier than you may think! See our [wiki article](wiki/migration/Switching-from-the-deprecated-official-version.md) for detailed instructions.

--- a/README.md
+++ b/README.md
@@ -23,15 +23,11 @@ A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android. He
 [//]: # (F-droid download image provided by F-Droid documentation)
 [//]: # (https://f-droid.org/docs/Badges/)
 
-<a href="https://f-droid.org/packages/com.github.catfriend1.syncthingfork" style="text-decoration:none;">
-    <img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" align="center" height="80"/>
-</a>
-<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/researchxxl/syncthing-android" style="text-decoration:none;">
-    <img src="https://github.com/ImranR98/Obtainium/blob/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" align="center" height="55"/>
-</a>
-<a href="https://github.com/researchxxl/syncthing-android/releases" style="text-decoration:none;">
-    <img src="https://raw.githubusercontent.com/rubenpgrady/get-it-on-github/refs/heads/main/get-it-on-github.png" alt="Download from GitHub" align="center" height="80"/>
-</a>
+[//]: # (Github for whatever reason likes to add zero width space behind each image link, smushing everything together like this should maybe fix it)
+
+<p align="left">
+  <a href="https://f-droid.org/packages/com.github.catfriend1.syncthingfork"><img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80" align="middle"></a><a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/researchxxl/syncthing-android"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" height="55" align="middle"></a><a href="https://github.com/researchxxl/syncthing-android/releases"><img src="https://raw.githubusercontent.com/rubenpgrady/get-it-on-github/refs/heads/main/get-it-on-github.png" alt="Download from GitHub" height="80" align="middle"></a>
+</p>
 
 ## Switching from the deprecated official version
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ A wrapper of [Syncthing](https://github.com/syncthing/syncthing) for Android. He
 [//]: # (F-droid download image provided by F-Droid documentation)
 [//]: # (https://f-droid.org/docs/Badges/)
 
-<a href="https://f-droid.org/packages/com.github.catfriend1.syncthingfork">
+<a href="https://f-droid.org/packages/com.github.catfriend1.syncthingfork" style="text-decoration:none;">
     <img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" align="center" height="80"/>
 </a>
-<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/researchxxl/syncthing-android">
-    <img src="https://github.com/ImranR98/Obtainium/blob/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" align="center" height="60"/>
+<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/researchxxl/syncthing-android" style="text-decoration:none;">
+    <img src="https://github.com/ImranR98/Obtainium/blob/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" align="center" height="55"/>
 </a>
-<a href="https://github.com/researchxxl/syncthing-android/releases">
+<a href="https://github.com/researchxxl/syncthing-android/releases" style="text-decoration:none;">
     <img src="https://raw.githubusercontent.com/rubenpgrady/get-it-on-github/refs/heads/main/get-it-on-github.png" alt="Download from GitHub" align="center" height="80"/>
 </a>
 


### PR DESCRIPTION
# Description
Add separate, large install buttons for F-Droid and GH releases. 
Added button for quick adding to [obtainium](https://github.com/ImranR98/Obtainium) app; works with current release asset format, will ask users for if they want to install the `syncthingfork` vs `syncthingandroid` named version. URL can be modified if this behavior is unfavorable.

# Changes
- Add README "Download" section
  - Add F-droid download
  - Add Github download
  - Add Obtainium download