### PR TITLE
fix(RunConditionMonitor): fix needing restart after changing sleep interval

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RunConditionMonitor.java
@@ -368,6 +368,7 @@ public class RunConditionMonitor {
     public void updateShouldRunDecision() {
         if (!Constants.isRunningOnEmulator()) {
             triggeredSyncDurationS = Integer.parseInt(mPreferences.getString(Constants.PREF_SYNC_DURATION_MINUTES, "5")) * 60;
+            triggeredSyncSleepIntervalS = Integer.parseInt(mPreferences.getString(Constants.PREF_SLEEP_INTERVAL_MINUTES, "60")) * 60;
         }
 
         boolean newShouldRun = decideShouldRun();


### PR DESCRIPTION
# Description
this should fix #106

# Changes
update the sleep interval value in instance whenever re-evaluating run conditions
