### PR TITLE
fix(importSettings): cast string to int

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsImportExportScreen.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsImportExportScreen.kt
@@ -299,8 +299,12 @@ private fun ImportConfigPreference() {
                                             ).show()
 
                                             // apply theme from restored config
-                                            val theme = prefs.value.get<Int>(Constants.PREF_APP_THEME)
-                                                ?: AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                                            val raw: Any? = prefs.value[Constants.PREF_APP_THEME]
+                                            val theme = when (raw) {
+                                                is Int -> raw
+                                                is String -> raw.toIntOrNull()
+                                                else -> null
+                                            } ?: AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
                                             AppCompatDelegate.setDefaultNightMode(theme)
 
                                             service.evaluateRunConditions()


### PR DESCRIPTION
if older zip export was used before material 3 migration of the settings screens (fixes #219)

