### PR TITLE
feat(RestApi): Trigger versioning cleanup every 10th app start to save resources

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/Constants.java
@@ -115,6 +115,7 @@ public class Constants {
     public static final String PREF_LOCAL_DEVICE_ID             = "localDeviceID";
     // from SystemClock.elapsedRealtime()
     public static final String PREF_LAST_RUN_TIME               = "last_run_time";
+    public static final String PREF_APP_START_COUNTER           = "app_start_counter";
 
     /**
      * Cached device stats.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -246,20 +246,26 @@ public class RestApi {
             // Tell SyncthingService it can transition to State.ACTIVE.
             mOnApiAvailableListener.onApiAvailable();
 
-            // Temporarily lower cleanupIntervalS for every folder to force cleanup after startup.
-            setVersioningCleanupIntervalS(2);
-            final Handler resetCleanupIntervalHandler = new Handler(Looper.getMainLooper());
-            resetCleanupIntervalHandler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    if (hasShutdown) {
-                        LogV("Skipping setVersioningCleanupIntervalS(3600) due to hasShutdown == true");
-                        return;
-                    }
-                    setVersioningCleanupIntervalS(3600);
-                }
-            }, 10000);
+            triggerVersioningCleanupIfNecessary();
         }
+    }
+
+    private void triggerVersioningCleanupIfNecessary() {
+        }
+
+        // Temporarily lower cleanupIntervalS for every folder to force cleanup after startup.
+        setVersioningCleanupIntervalS(2);
+        final Handler resetCleanupIntervalHandler = new Handler(Looper.getMainLooper());
+        resetCleanupIntervalHandler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (hasShutdown) {
+                    LogV("Skipping setVersioningCleanupIntervalS(3600) due to hasShutdown == true");
+                    return;
+                }
+                setVersioningCleanupIntervalS(3600);
+            }
+        }, 10000); 
     }
 
     public void reloadConfig() {

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/RestApi.java
@@ -251,6 +251,16 @@ public class RestApi {
     }
 
     private void triggerVersioningCleanupIfNecessary() {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
+        int startupCounter = sharedPreferences.getInt(Constants.PREF_APP_START_COUNTER, 0) + 1;
+        startupCounter = (startupCounter == Integer.MAX_VALUE) ? 1 : startupCounter;
+        sharedPreferences.edit()
+            .putInt(Constants.PREF_APP_START_COUNTER, startupCounter)
+            .apply();
+        boolean shouldRunWorkaround = (startupCounter % 10 == 0);
+        if (!shouldRunWorkaround) {
+            LogV("Skipping versioning cleanup because it is only triggered every 10th startup to save resources.");
+            return;
         }
 
         // Temporarily lower cleanupIntervalS for every folder to force cleanup after startup.

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -1144,6 +1144,7 @@ public class SyncthingService extends Service {
                             LogV("importConfig: Ignoring deprecated pref \"" + prefKey + "\".");
                             break;
                         // Cached information which is not available on SettingsActivity.
+                        case Constants.PREF_APP_START_COUNTER:
                         case Constants.PREF_BTNSTATE_FORCE_START_STOP:
                         case Constants.PREF_DEBUG_FACILITIES_AVAILABLE:
                         case Constants.PREF_EVENT_PROCESSOR_LAST_SYNC_ID:


### PR DESCRIPTION
Before: triggered on every app start, potentially traversing large directory trees with Android's slow SAF or FS layer (especially on Android 11)
After: trigger every 10th app start so cleanup is not missed if the user occasionally and manually starts and exits the app

This will not (visibly) affect installs where Syncthing is configured to run continously with uptimes greater than the default cleanup interval S which is 3600s 