### PR TITLE
feature: support custom https certificate (closes #222)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/ApiRequest.java
@@ -28,6 +28,7 @@ import com.nutomic.syncthingandroid.service.Constants;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -82,10 +83,42 @@ public abstract class ApiRequest {
 
     ApiRequest(Context context, URL url, String path, String apiKey) {
         mContext = context;
-        mUrl           = url;
+        // The app only ever talks to the local syncthing instance. Pin the connection to the
+        // loopback interface regardless of the configured GUI listen address (which is 0.0.0.0
+        // when remote access is enabled), keeping the API key and config off any routable interface.
+        mUrl           = forceLoopbackHost(url);
         mPath          = path;
         mApiKey        = apiKey;
         ENABLE_VERBOSE_LOG = AppPrefs.getPrefVerboseLog(context);
+    }
+
+    /**
+     * Rewrites the host of the given URL to 127.0.0.1, preserving the scheme and port. The port
+     * comes from the configured GUI listen address; falls back to the default web GUI port.
+     *
+     * <p>Forcing loopback is intentional and security-relevant, not merely a convenience:
+     * <ul>
+     *   <li>The app only ever sets the GUI address to {@code 127.0.0.1} or {@code 0.0.0.0} (the
+     *       "listen on all interfaces" setting). {@code 0.0.0.0} always includes loopback, so the
+     *       local instance is reachable on {@code 127.0.0.1} in every app-managed config.</li>
+     *   <li>It keeps the API key and configuration off any routable interface.</li>
+     *   <li>It is the precondition that makes the two TLS relaxations safe: disabling hostname
+     *       verification ({@link NetworkStack#createConnection}) and falling back to the OS trust
+     *       store / user-installed CAs ({@link SyncthingTrustManager}). On loopback there is no
+     *       network position for a MITM to occupy, so neither relaxation can be abused.</li>
+     * </ul>
+     * Do not "simplify" this by connecting to the configured address directly: {@code 0.0.0.0} is
+     * not a valid destination (and modern WebView blocks it), and targeting a routable address
+     * would break the trust model above.
+     */
+    private static URL forceLoopbackHost(URL url) {
+        try {
+            int port = url.getPort() != -1 ? url.getPort() : Constants.DEFAULT_WEBGUI_TCP_PORT;
+            return new URL(url.getProtocol(), "127.0.0.1", port, url.getFile());
+        } catch (MalformedURLException e) {
+            Log.w(TAG, "forceLoopbackHost: Failed to rewrite host, using original URL", e);
+            return url;
+        }
     }
 
     Uri buildUri(Map<String, String> params) {
@@ -203,6 +236,12 @@ public abstract class ApiRequest {
         protected HttpURLConnection createConnection(URL url) throws IOException {
             if (mUrl.toString().startsWith("https://")) {
                 HttpsURLConnection connection = (HttpsURLConnection) super.createConnection(url);
+                // Safe to skip hostname verification: the connection is pinned to the loopback
+                // interface (see forceLoopbackHost), so there is no network MITM surface and the
+                // certificate's SAN/CN need not match 127.0.0.1 (a user-supplied CA cert is
+                // typically issued for a real hostname, not the loopback address). Trust is still
+                // enforced by SyncthingTrustManager: the self-signed pin first, then the OS trust
+                // store.
                 connection.setHostnameVerifier((hostname, session) -> true);
                 return connection;
             }

--- a/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/http/SyncthingTrustManager.java
@@ -3,6 +3,8 @@ package com.nutomic.syncthingandroid.http;
 import android.annotation.SuppressLint;
 import android.util.Log;
 
+import com.nutomic.syncthingandroid.util.Util;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -22,6 +24,17 @@ import javax.net.ssl.X509TrustManager;
  * TrustManager checking against the local Syncthing instance's https public key.
  *
  * Based on http://stackoverflow.com/questions/16719959#16759793
+ *
+ * The local Syncthing instance ships a self-signed certificate by default, which is verified by
+ * pinning against the public key stored in https-cert.pem. A user may instead replace the HTTPS
+ * certificate with one signed by a CA they trust at the Android OS level (see
+ * https://github.com/researchxxl/syncthing-android/issues/222); for that case we fall back to the
+ * OS trust store when the self-signed pin does not match.
+ *
+ * Security scope: this trust manager is only ever wired into the loopback-pinned connection to the
+ * local Syncthing instance (see ApiRequest#forceLoopbackHost). Because that connection cannot leave
+ * the device, falling back to the OS trust store — which trusts user-installed CAs — does not open a
+ * network MITM surface. Do not reuse this trust manager for any routable/remote connection.
  */
 class SyncthingTrustManager implements X509TrustManager {
 
@@ -40,11 +53,34 @@ class SyncthingTrustManager implements X509TrustManager {
     }
 
     /**
-     * Verifies certs against public key of the local syncthing instance
+     * Verifies certs against the public key of the local syncthing instance (self-signed pin).
+     * If that fails, falls back to the Android OS trust store, which validates CA-signed
+     * certificates against the system and user-installed certificate authorities.
      */
     @Override
     public void checkServerTrusted(X509Certificate[] certs,
                                    String authType) throws CertificateException {
+        try {
+            verifyAgainstPinnedCert(certs);
+        } catch (CertificateException pinFailure) {
+            // The presented certificate is not the pinned self-signed certificate. This is expected
+            // when the user replaced the HTTPS certificate with a CA-signed one, so fall back to the
+            // Android OS trust store instead of failing the connection outright. Logged at debug
+            // level to avoid spamming logcat with the wrapped BAD_SIGNATURE on every request.
+            Log.d(TAG, "Pinned certificate did not match, trying Android OS trust store.");
+            X509TrustManager osTrustManager = Util.getOsTrustManager();
+            if (osTrustManager == null) {
+                throw pinFailure;
+            }
+            osTrustManager.checkServerTrusted(certs, authType);
+        }
+    }
+
+    /**
+     * Verifies that every presented certificate is signed by the public key of the certificate
+     * pinned in {@link #mHttpsCertPath} (the certificate the local syncthing instance generated).
+     */
+    private void verifyAgainstPinnedCert(X509Certificate[] certs) throws CertificateException {
         InputStream is = null;
         try {
             is = new FileInputStream(mHttpsCertPath);
@@ -65,6 +101,7 @@ class SyncthingTrustManager implements X509TrustManager {
             }
         }
     }
+
     public X509Certificate[] getAcceptedIssuers() {
         return null;
     }

--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingService.java
@@ -152,6 +152,22 @@ public class SyncthingService extends Service {
     }
 
     /**
+     * Outcome of {@link #replaceHttpsCertificate} / {@link #resetHttpsCertificate}.
+     */
+    public enum HttpsCertReplaceResult {
+        /** The new certificate was applied and Syncthing came back online with it. */
+        SUCCESS,
+        /** The files were written but Syncthing is not currently meant to run; applies on next start. */
+        SUCCESS_PENDING_START,
+        /** The change failed and the previous certificate was restored. */
+        FAILED
+    }
+
+    public interface OnHttpsCertReplaceResultListener {
+        void onResult(HttpsCertReplaceResult result, @Nullable String errorDetail);
+    }
+
+    /**
      * Indicates the current state of SyncthingService and of Syncthing itself.
      */
     public enum State {
@@ -1061,6 +1077,234 @@ public class SyncthingService extends Service {
             mainLooper.post(launchStartupTaskRunnable);
         }
         return failSuccess;
+    }
+
+    /**
+     * Backstop timeout for {@link #verifyRestartAndRollback} in case the state machine never reaches
+     * a terminal state (e.g. the binary crashed via a path that doesn't transition to ERROR).
+     */
+    private static final long HTTPS_CERT_VERIFY_TIMEOUT_MS = 30000;
+
+    /**
+     * Replaces the Web GUI HTTPS certificate and key with the supplied PEM bytes, then restarts
+     * Syncthing so the new files take effect. If the restart fails to bring the Web GUI back online,
+     * the previous certificate and key are restored automatically.
+     *
+     * The bytes are expected to already be validated (see {@link com.nutomic.syncthingandroid.util.CertificateValidator}).
+     * The whole start/stop lifecycle is marshalled onto the main thread because the binary
+     * orchestration fields are only safe to touch there.
+     */
+    public void replaceHttpsCertificate(byte[] certPem, byte[] keyPem,
+                                        OnHttpsCertReplaceResultListener listener) {
+        mHandler.post(() -> doReplaceHttpsCertificate(certPem, keyPem, listener));
+    }
+
+    /**
+     * Deletes the user-supplied HTTPS certificate/key so Syncthing regenerates a fresh self-signed
+     * certificate at the next start, then restarts (with rollback on failure).
+     */
+    public void resetHttpsCertificate(OnHttpsCertReplaceResultListener listener) {
+        mHandler.post(() -> doResetHttpsCertificate(listener));
+    }
+
+    private void doReplaceHttpsCertificate(byte[] certPem, byte[] keyPem,
+                                           OnHttpsCertReplaceResultListener listener) {
+        // shutdown() defers while STARTING; wait it out so our file writes don't race the binary.
+        if (mCurrentState == State.STARTING) {
+            mHandler.postDelayed(() -> doReplaceHttpsCertificate(certPem, keyPem, listener), 1000);
+            return;
+        }
+
+        final File certFile = Constants.getHttpsCertFile(this);
+        final File keyFile = Constants.getHttpsKeyFile(this);
+
+        // Stop the binary so it releases the cert/key before we overwrite them.
+        if (mCurrentState != State.DISABLED) {
+            shutdown(State.DISABLED);
+        }
+
+        final File certBak = backupFile(certFile);
+        final File keyBak = backupFile(keyFile);
+
+        try {
+            writeBytesAtomic(certFile, certPem);
+            writeBytesAtomic(keyFile, keyPem);
+            restrictToOwner(keyFile);
+        } catch (IOException e) {
+            Log.e(TAG, "doReplaceHttpsCertificate: Failed to write new cert/key", e);
+            restoreFile(certBak, certFile);
+            restoreFile(keyBak, keyFile);
+            if (mLastDeterminedShouldRun) {
+                launchStartupTask(SyncthingRunnable.Command.main);
+            }
+            listener.onResult(HttpsCertReplaceResult.FAILED, e.getMessage());
+            return;
+        }
+
+        applyCertChangeWithVerify(certFile, keyFile, certBak, keyBak, listener);
+    }
+
+    private void doResetHttpsCertificate(OnHttpsCertReplaceResultListener listener) {
+        if (mCurrentState == State.STARTING) {
+            mHandler.postDelayed(() -> doResetHttpsCertificate(listener), 1000);
+            return;
+        }
+
+        final File certFile = Constants.getHttpsCertFile(this);
+        final File keyFile = Constants.getHttpsKeyFile(this);
+
+        if (mCurrentState != State.DISABLED) {
+            shutdown(State.DISABLED);
+        }
+
+        final File certBak = backupFile(certFile);
+        final File keyBak = backupFile(keyFile);
+        // Removing the files makes syncthing generate a fresh self-signed certificate at startup.
+        deleteQuietly(certFile);
+        deleteQuietly(keyFile);
+
+        applyCertChangeWithVerify(certFile, keyFile, certBak, keyBak, listener);
+    }
+
+    private void applyCertChangeWithVerify(File certFile, File keyFile,
+                                           @Nullable File certBak, @Nullable File keyBak,
+                                           OnHttpsCertReplaceResultListener listener) {
+        if (mLastDeterminedShouldRun) {
+            verifyRestartAndRollback(certFile, keyFile, certBak, keyBak, listener);
+        } else {
+            // Not currently meant to run; the new files will take effect on next start.
+            deleteQuietly(certBak);
+            deleteQuietly(keyBak);
+            listener.onResult(HttpsCertReplaceResult.SUCCESS_PENDING_START, null);
+        }
+    }
+
+    /**
+     * Restarts the binary and watches the service state: success on reaching ACTIVE, failure on
+     * ERROR / an abnormal STARTING&rarr;DISABLED transition (crashed binary) / a watchdog timeout.
+     * On failure the backed-up cert/key are restored and a known-good instance is brought back up.
+     */
+    private void verifyRestartAndRollback(File certFile, File keyFile,
+                                          @Nullable File certBak, @Nullable File keyBak,
+                                          OnHttpsCertReplaceResultListener listener) {
+        final boolean[] resolved = {false};
+        final boolean[] sawStarting = {false};
+        final OnServiceStateChangeListener[] verifyListener = new OnServiceStateChangeListener[1];
+        final Runnable[] watchdog = new Runnable[1];
+
+        final Runnable finishSuccess = () -> {
+            deleteQuietly(certBak);
+            deleteQuietly(keyBak);
+            listener.onResult(HttpsCertReplaceResult.SUCCESS, null);
+        };
+        final Runnable finishFailure = () -> {
+            restoreFile(certBak, certFile);
+            restoreFile(keyBak, keyFile);
+            // Bring the previous, known-good certificate back online.
+            if (mCurrentState != State.DISABLED && mCurrentState != State.INIT) {
+                shutdown(State.INIT);
+            }
+            launchStartupTask(SyncthingRunnable.Command.main);
+            listener.onResult(HttpsCertReplaceResult.FAILED,
+                    "Syncthing did not come online with the new certificate.");
+        };
+
+        watchdog[0] = () -> {
+            if (resolved[0]) {
+                return;
+            }
+            resolved[0] = true;
+            unregisterOnServiceStateChangeListener(verifyListener[0]);
+            if (mCurrentState == State.ACTIVE) {
+                finishSuccess.run();
+            } else {
+                finishFailure.run();
+            }
+        };
+
+        verifyListener[0] = (state) -> {
+            if (resolved[0]) {
+                return;
+            }
+            if (state == State.STARTING) {
+                sawStarting[0] = true;
+                return;
+            }
+            final boolean success = (state == State.ACTIVE);
+            final boolean failure = (state == State.ERROR) || (sawStarting[0] && state == State.DISABLED);
+            if (!success && !failure) {
+                return;
+            }
+            resolved[0] = true;
+            mHandler.removeCallbacks(watchdog[0]);
+            // Defer unregister + lifecycle work out of onServiceStateChange's listener iteration.
+            mHandler.post(() -> {
+                unregisterOnServiceStateChangeListener(verifyListener[0]);
+                if (success) {
+                    finishSuccess.run();
+                } else {
+                    finishFailure.run();
+                }
+            });
+        };
+
+        // registerOnServiceStateChangeListener replays the current state (DISABLED) synchronously;
+        // that is ignored because sawStarting is still false.
+        registerOnServiceStateChangeListener(verifyListener[0]);
+        mHandler.postDelayed(watchdog[0], HTTPS_CERT_VERIFY_TIMEOUT_MS);
+        launchStartupTask(SyncthingRunnable.Command.main);
+    }
+
+    @Nullable
+    private File backupFile(File file) {
+        if (!file.exists()) {
+            return null;
+        }
+        File bak = new File(file.getParentFile(), file.getName() + ".bak");
+        deleteQuietly(bak);
+        if (file.renameTo(bak)) {
+            return bak;
+        }
+        Log.w(TAG, "backupFile: Failed to back up " + file.getName());
+        return null;
+    }
+
+    private void restoreFile(@Nullable File bak, File target) {
+        if (bak == null || !bak.exists()) {
+            return;
+        }
+        deleteQuietly(target);
+        if (!bak.renameTo(target)) {
+            Log.w(TAG, "restoreFile: Failed to restore " + target.getName());
+        }
+    }
+
+    private void deleteQuietly(@Nullable File file) {
+        if (file != null && file.exists() && !file.delete()) {
+            Log.w(TAG, "deleteQuietly: Failed to delete " + file.getName());
+        }
+    }
+
+    private void writeBytesAtomic(File target, byte[] data) throws IOException {
+        File tmp = new File(target.getParentFile(), target.getName() + ".tmp");
+        try (FileOutputStream fos = new FileOutputStream(tmp)) {
+            fos.write(data);
+            fos.flush();
+            fos.getFD().sync();
+        }
+        if (!tmp.renameTo(target)) {
+            deleteQuietly(tmp);
+            throw new IOException("Failed to rename " + tmp.getName() + " to " + target.getName());
+        }
+    }
+
+    private void restrictToOwner(File file) {
+        // Mirror syncthing core, which writes the HTTPS key with 0600 permissions.
+        file.setReadable(false, false);
+        file.setReadable(true, true);
+        file.setWritable(false, false);
+        file.setWritable(true, true);
+        file.setExecutable(false, false);
     }
 
     private void cleanupImportedFolderDatabases() {

--- a/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsCustomCertificateScreen.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsCustomCertificateScreen.kt
@@ -1,0 +1,360 @@
+package com.nutomic.syncthingandroid.settings
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.EntryProviderScope
+import com.nutomic.syncthingandroid.R
+import com.nutomic.syncthingandroid.service.Constants
+import com.nutomic.syncthingandroid.service.SyncthingService
+import com.nutomic.syncthingandroid.util.CertificateValidator
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import me.zhanghai.compose.preference.Preference
+import me.zhanghai.compose.preference.PreferenceCategory
+
+private const val MAX_PEM_BYTES = 512 * 1024
+
+fun EntryProviderScope<SettingsRoute>.settingsCustomCertificateEntry() {
+    entry<SettingsRoute.CustomCertificate> {
+        SettingsCustomCertificateScreen()
+    }
+}
+
+@Composable
+fun SettingsCustomCertificateScreen() {
+    val context = LocalContext.current
+    val navigator = LocalSettingsNavigator.current
+    val stService = LocalSyncthingService.current
+
+    var certBytes by remember { mutableStateOf<ByteArray?>(null) }
+    var keyBytes by remember { mutableStateOf<ByteArray?>(null) }
+    var certName by remember { mutableStateOf<String?>(null) }
+    var keyName by remember { mutableStateOf<String?>(null) }
+    var validation by remember { mutableStateOf<CertificateValidator.ValidationResult?>(null) }
+    var currentInfo by remember { mutableStateOf<CertificateValidator.CertInfo?>(null) }
+    var applying by remember { mutableStateOf(false) }
+    var showResetDialog by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        currentInfo = withContext(Dispatchers.IO) {
+            try {
+                val file = Constants.getHttpsCertFile(context)
+                if (file.exists()) CertificateValidator.describe(file.readBytes()) else null
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+
+    LaunchedEffect(certBytes, keyBytes) {
+        val c = certBytes
+        val k = keyBytes
+        validation = if (c != null && k != null)
+            withContext(Dispatchers.IO) { CertificateValidator.validate(c, k) }
+        else
+            null
+    }
+
+    val certPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        readPicked(context, uri)?.let { (name, bytes) -> certName = name; certBytes = bytes }
+    }
+    val keyPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        readPicked(context, uri)?.let { (name, bytes) -> keyName = name; keyBytes = bytes }
+    }
+
+    val canApply = validation?.canApply == true && stService != null && !applying
+
+    SettingsScaffold(title = stringResource(R.string.webui_custom_cert_title)) {
+        item {
+            PreferenceCategory(
+                title = { Text(stringResource(R.string.preference_category_explanation)) }
+            )
+        }
+        item {
+            Preference(
+                title = { Text(stringResource(R.string.custom_cert_explanation)) }
+            )
+        }
+
+        item { CurrentCertificateCard(currentInfo) }
+
+        item {
+            Preference(
+                title = { Text(stringResource(R.string.custom_cert_select_cert)) },
+                summary = { Text(certName ?: stringResource(R.string.custom_cert_not_selected)) },
+                enabled = !applying,
+                onClick = { certPicker.launch(arrayOf("*/*")) },
+            )
+        }
+        item {
+            Preference(
+                title = { Text(stringResource(R.string.custom_cert_select_key)) },
+                summary = { Text(keyName ?: stringResource(R.string.custom_cert_not_selected)) },
+                enabled = !applying,
+                onClick = { keyPicker.launch(arrayOf("*/*")) },
+            )
+        }
+
+        validation?.let { result ->
+            val parseError = result.parseError
+            if (parseError != null) {
+                item { CheckRow(CertificateValidator.Status.FAIL, parseError, null) }
+            } else {
+                result.checks.forEach { check ->
+                    item {
+                        CheckRow(check.status, stringResource(checkTitle(check.check)), check.detail)
+                    }
+                }
+            }
+        }
+
+        item {
+            Preference(
+                title = {
+                    Button(
+                        onClick = {
+                            val result = validation
+                            val service = stService
+                            if (result != null && result.canApply && service != null && !applying) {
+                                applying = true
+                                service.replaceHttpsCertificate(result.certPem, result.keyPem) { outcome, detail ->
+                                    applying = false
+                                    handleOutcome(context, navigator, outcome, detail)
+                                }
+                            }
+                        },
+                        enabled = canApply,
+                        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
+                    ) {
+                        Text(stringResource(R.string.custom_cert_apply))
+                    }
+                },
+                summary = {
+                    Box(
+                        modifier = Modifier.height(24.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        AnimatedVisibility(
+                            visible = applying,
+                            enter = fadeIn(animationSpec = tween(durationMillis = 120)),
+                            exit = fadeOut(animationSpec = tween(durationMillis = 120)),
+                        ) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(18.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                                Spacer(Modifier.width(12.dp))
+                                Text(
+                                    text = stringResource(R.string.custom_cert_applying),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                        }
+                    }
+                }
+            )
+        }
+        item {
+            Preference(
+                title = { Text(stringResource(R.string.custom_cert_reset_title)) },
+                summary = { Text(stringResource(R.string.custom_cert_reset_summary)) },
+                enabled = stService != null && !applying,
+                onClick = { showResetDialog = true },
+            )
+        }
+    }
+
+    if (showResetDialog) {
+        AlertDialog(
+            onDismissRequest = { showResetDialog = false },
+            title = { Text(stringResource(R.string.custom_cert_reset_title)) },
+            text = { Text(stringResource(R.string.custom_cert_reset_question)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showResetDialog = false
+                    val service = stService
+                    if (service != null && !applying) {
+                        applying = true
+                        service.resetHttpsCertificate { outcome, detail ->
+                            applying = false
+                            if (outcome == SyncthingService.HttpsCertReplaceResult.FAILED) {
+                                handleOutcome(context, navigator, outcome, detail)
+                            } else {
+                                Toast.makeText(
+                                    context.applicationContext,
+                                    R.string.custom_cert_reset_done,
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                                navigator.navigateUp()
+                            }
+                        }
+                    }
+                }) { Text(stringResource(android.R.string.ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetDialog = false }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun CurrentCertificateCard(info: CertificateValidator.CertInfo?) {
+    PreferenceCategory(
+        title = { Text(stringResource(R.string.custom_cert_current_title)) },
+    )
+    Preference(
+        title = {
+            if (info == null) {
+                Text(stringResource(R.string.custom_cert_current_none))
+            } else {
+                Text(stringResource(R.string.custom_cert_subject, info.subject))
+                Text(stringResource(R.string.custom_cert_issuer, info.issuer))
+                Text(stringResource(R.string.custom_cert_expires, info.notAfter))
+                Text(stringResource(if (info.selfSigned) R.string.custom_cert_self_signed else R.string.custom_cert_ca_signed))
+            }
+        },
+    )
+}
+
+@Composable
+private fun CheckRow(status: CertificateValidator.Status, title: String, detail: String?) {
+    val (icon, tint) = when (status) {
+        CertificateValidator.Status.PASS -> Icons.Filled.CheckCircle to Color(0xFF2E7D32)
+        CertificateValidator.Status.WARN -> Icons.Filled.Warning to Color(0xFFF9A825)
+        CertificateValidator.Status.FAIL -> Icons.Filled.Error to MaterialTheme.colorScheme.error
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(22.dp))
+        Spacer(Modifier.width(16.dp))
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            if (!detail.isNullOrBlank()) {
+                Text(
+                    detail,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private fun checkTitle(check: CertificateValidator.Check): Int = when (check) {
+    CertificateValidator.Check.CHAIN -> R.string.cert_check_chain
+    CertificateValidator.Check.TRUST -> R.string.cert_check_trust
+    CertificateValidator.Check.VALIDITY -> R.string.cert_check_validity
+    CertificateValidator.Check.KEY -> R.string.cert_check_key
+}
+
+private fun handleOutcome(
+    context: Context,
+    navigator: Navigator<SettingsRoute>,
+    outcome: SyncthingService.HttpsCertReplaceResult?,
+    detail: String?,
+) {
+    when (outcome) {
+        SyncthingService.HttpsCertReplaceResult.SUCCESS -> {
+            Toast.makeText(context.applicationContext, R.string.custom_cert_applied, Toast.LENGTH_LONG).show()
+            navigator.navigateUp()
+        }
+        SyncthingService.HttpsCertReplaceResult.SUCCESS_PENDING_START -> {
+            Toast.makeText(context.applicationContext, R.string.custom_cert_applied_pending, Toast.LENGTH_LONG).show()
+            navigator.navigateUp()
+        }
+        else -> {
+            Toast.makeText(
+                context.applicationContext,
+                context.getString(R.string.custom_cert_failed, detail ?: ""),
+                Toast.LENGTH_LONG,
+            ).show()
+        }
+    }
+}
+
+private fun readPicked(context: Context, uri: Uri?): Pair<String, ByteArray>? {
+    if (uri == null) {
+        return null
+    }
+    return try {
+        val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        if (bytes == null) {
+            toast(context, R.string.custom_cert_read_failed)
+            null
+        } else if (bytes.size > MAX_PEM_BYTES) {
+            toast(context, R.string.custom_cert_file_too_large)
+            null
+        } else {
+            (queryDisplayName(context, uri) ?: "selected file") to bytes
+        }
+    } catch (e: Exception) {
+        toast(context, R.string.custom_cert_read_failed)
+        null
+    }
+}
+
+private fun queryDisplayName(context: Context, uri: Uri): String? {
+    return context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+        ?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0) cursor.getString(index) else null
+            } else {
+                null
+            }
+        }
+}
+
+private fun toast(context: Context, resId: Int) {
+    Toast.makeText(context.applicationContext, resId, Toast.LENGTH_LONG).show()
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsNavigation.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsNavigation.kt
@@ -38,6 +38,8 @@ sealed interface SettingsRoute : NavKey {
     @Serializable
     data object SyncthingOptions : SettingsRoute
     @Serializable
+    data object CustomCertificate : SettingsRoute
+    @Serializable
     data object ImportExport : SettingsRoute
     @Serializable
     data object Troubleshooting : SettingsRoute
@@ -58,6 +60,7 @@ sealed interface SettingsRoute : NavKey {
             "UserInterface" -> UserInterface
             "Behavior" -> Behavior
             "SyncthingOptions" -> SyncthingOptions
+            "CustomCertificate" -> CustomCertificate
             "ImportExport" -> ImportExport
             "Troubleshooting" -> Troubleshooting
             "Experimental" -> Experimental
@@ -112,6 +115,7 @@ fun SettingsNavDisplay(
             settingsUserInterfaceEntry()
             settingsBehaviorEntry()
             settingsSyncthingOptionsEntry()
+            settingsCustomCertificateEntry()
             settingsImportExportEntry()
             settingsTroubleshootingEntry()
             settingsExperimentalEntry()

--- a/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsSyncthingOptionsScreen.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsSyncthingOptionsScreen.kt
@@ -94,6 +94,7 @@ fun SettingsSyncthingOptionsScreen() {
     val stService = LocalSyncthingService.current
     val stServiceTick = LocalServiceUpdateTick.current
     val scope = LocalActivityScope.current
+    val navigator = LocalSettingsNavigator.current
 
     val sharedPrefWebGuiPassword = rememberPreferenceState(Constants.PREF_WEBUI_PASSWORD, "")
 
@@ -328,6 +329,15 @@ fun SettingsSyncthingOptionsScreen() {
                     },
                     textToValue = { it },
                     enabled = isStServiceActive,
+                )
+            }
+            item {
+                Preference(
+                    title = { Text(stringResource(R.string.webui_custom_cert_title)) },
+                    summary = { Text(stringResource(R.string.webui_custom_cert_summary)) },
+                    onClick = { navigator.navigateTo(SettingsRoute.CustomCertificate) },
+                    // The custom certificate only matters when the GUI is served over HTTPS.
+                    enabled = stService != null && Constants.osSupportsTLS12(),
                 )
             }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsSyncthingOptionsScreen.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/settings/SettingsSyncthingOptionsScreen.kt
@@ -331,15 +331,6 @@ fun SettingsSyncthingOptionsScreen() {
                     enabled = isStServiceActive,
                 )
             }
-            item {
-                Preference(
-                    title = { Text(stringResource(R.string.webui_custom_cert_title)) },
-                    summary = { Text(stringResource(R.string.webui_custom_cert_summary)) },
-                    onClick = { navigator.navigateTo(SettingsRoute.CustomCertificate) },
-                    // The custom certificate only matters when the GUI is served over HTTPS.
-                    enabled = stService != null && Constants.osSupportsTLS12(),
-                )
-            }
 
             item {
                 PreferenceCategory(
@@ -351,6 +342,15 @@ fun SettingsSyncthingOptionsScreen() {
                     title = { Text(stringResource(R.string.crash_reporting)) },
                     state = crashReporting,
                     enabled = isStServiceActive,
+                )
+            }
+            item {
+                Preference(
+                    title = { Text(stringResource(R.string.webui_custom_cert_title)) },
+                    summary = { Text(stringResource(R.string.webui_custom_cert_summary)) },
+                    onClick = { navigator.navigateTo(SettingsRoute.CustomCertificate) },
+                    // The custom certificate only matters when the GUI is served over HTTPS.
+                    enabled = stService != null && Constants.osSupportsTLS12(),
                 )
             }
             item {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/CertificateValidator.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/CertificateValidator.kt
@@ -1,0 +1,270 @@
+package com.nutomic.syncthingandroid.util
+
+import android.util.Base64
+import java.io.ByteArrayInputStream
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.cert.CertificateExpiredException
+import java.security.cert.CertificateFactory
+import java.security.cert.CertificateNotYetValidException
+import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.text.DateFormat
+
+/**
+ * Validates a user-supplied HTTPS certificate (+ private key) that is about to replace the local
+ * Syncthing Web GUI certificate.
+ *
+ * The decisive check is [Check.TRUST]: it mirrors [com.nutomic.syncthingandroid.http.SyncthingTrustManager]
+ * exactly (self-signed pin OR a chain that validates against the Android OS trust store via
+ * [Util.getOsTrustManager]). If that passes, the app will be able to talk to Syncthing once the cert
+ * is installed. The private-key match is best-effort: Syncthing's own `tls.LoadX509KeyPair` at the
+ * post-replace restart is the authoritative arbiter, with automatic rollback on failure.
+ */
+object CertificateValidator {
+
+    enum class Status { PASS, WARN, FAIL }
+
+    /** The kinds of checks performed; the UI maps each to a localized title. */
+    enum class Check { CHAIN, TRUST, VALIDITY, KEY }
+
+    data class CheckResult(val check: Check, val status: Status, val detail: String? = null)
+
+    data class CertInfo(
+        val subject: String,
+        val issuer: String,
+        val notAfter: String,
+        val selfSigned: Boolean,
+    )
+
+    class ValidationResult(
+        /** Non-null when the files could not even be parsed into a cert + key pair. */
+        val parseError: String?,
+        val checks: List<CheckResult>,
+        val canApply: Boolean,
+        /** Normalized certificate PEM bytes to write (auto-corrected if the user swapped the pickers). */
+        val certPem: ByteArray,
+        /** Normalized private-key PEM bytes to write. */
+        val keyPem: ByteArray,
+        val info: CertInfo?,
+    )
+
+    private val NONCE = "syncthing-android-cert-key-match-probe".toByteArray()
+
+    /**
+     * Validates the two picked files. The arguments are passed in the order the user assigned them
+     * (certificate slot, key slot) but are auto-corrected if swapped, based on their PEM block type.
+     */
+    fun validate(certSlot: ByteArray, keySlot: ByteArray): ValidationResult {
+        val aIsCert = looksLikeCertificate(certSlot)
+        val bIsCert = looksLikeCertificate(keySlot)
+        val aIsKey = looksLikeKey(certSlot)
+        val bIsKey = looksLikeKey(keySlot)
+
+        val certBytes: ByteArray
+        val keyBytes: ByteArray
+        when {
+            aIsCert && bIsKey -> { certBytes = certSlot; keyBytes = keySlot }
+            bIsCert && aIsKey -> { certBytes = keySlot; keyBytes = certSlot } // swapped
+            aIsCert && bIsCert -> return fail("Both files are certificates — one must be the private key.", certSlot, keySlot)
+            aIsKey && bIsKey -> return fail("Both files are private keys — one must be the certificate.", certSlot, keySlot)
+            !aIsCert && !bIsCert -> return fail("No PEM certificate found in the selected files.", certSlot, keySlot)
+            aIsCert -> { certBytes = certSlot; keyBytes = keySlot }
+            else -> { certBytes = keySlot; keyBytes = certSlot }
+        }
+
+        val chain: List<X509Certificate> = try {
+            parseChain(certBytes)
+        } catch (e: Exception) {
+            return fail("Could not read the certificate: ${e.message}", certSlot, keySlot)
+        }
+        if (chain.isEmpty()) {
+            return fail("The certificate file contains no certificates.", certSlot, keySlot)
+        }
+
+        val leaf = chain.first()
+        val checks = listOf(
+            chainCheck(chain),
+            trustCheck(chain, leaf),
+            validityCheck(chain),
+            keyCheck(keyBytes, leaf),
+        )
+
+        val trust = checks.first { it.check == Check.TRUST }
+        val validity = checks.first { it.check == Check.VALIDITY }
+        val key = checks.first { it.check == Check.KEY }
+        val canApply = trust.status == Status.PASS &&
+                validity.status == Status.PASS &&
+                key.status != Status.FAIL
+
+        return ValidationResult(null, checks, canApply, certBytes, keyBytes, certInfo(leaf))
+    }
+
+    /** Parses the (currently installed) certificate file for display, or null if unreadable. */
+    fun describe(certBytes: ByteArray): CertInfo? = try {
+        parseChain(certBytes).firstOrNull()?.let { certInfo(it) }
+    } catch (e: Exception) {
+        null
+    }
+
+    // --- individual checks ---------------------------------------------------------------------
+
+    private fun chainCheck(chain: List<X509Certificate>): CheckResult {
+        if (chain.size == 1) {
+            return if (isSelfSigned(chain[0]))
+                CheckResult(Check.CHAIN, Status.PASS, "Self-signed certificate.")
+            else
+                CheckResult(
+                    Check.CHAIN, Status.WARN,
+                    "Only the leaf certificate is present — include the intermediate(s) so the chain is complete."
+                )
+        }
+        for (i in 0 until chain.size - 1) {
+            try {
+                chain[i].verify(chain[i + 1].publicKey)
+            } catch (e: Exception) {
+                return CheckResult(
+                    Check.CHAIN, Status.WARN,
+                    "Certificates may be out of order or an intermediate is missing."
+                )
+            }
+        }
+        return CheckResult(Check.CHAIN, Status.PASS, "Full chain present (${chain.size} certificates).")
+    }
+
+    private fun trustCheck(chain: List<X509Certificate>, leaf: X509Certificate): CheckResult {
+        // Self-signed pin path — mirrors SyncthingTrustManager.verifyAgainstPinnedCert.
+        if (isSelfSigned(leaf)) {
+            return CheckResult(Check.TRUST, Status.PASS, "Self-signed — the app will pin this certificate.")
+        }
+        val tm = Util.getOsTrustManager()
+            ?: return CheckResult(Check.TRUST, Status.FAIL, "The Android trust store is unavailable.")
+        return try {
+            tm.checkServerTrusted(chain.toTypedArray(), authType(leaf))
+            CheckResult(
+                Check.TRUST, Status.PASS,
+                "Trusted by Android (chain validated; the hostname is intentionally not checked for the local connection)."
+            )
+        } catch (e: Exception) {
+            CheckResult(
+                Check.TRUST, Status.FAIL,
+                "Not trusted by Android — install your root CA on the device and include the full chain."
+            )
+        }
+    }
+
+    private fun validityCheck(chain: List<X509Certificate>): CheckResult {
+        for (c in chain) {
+            try {
+                c.checkValidity()
+            } catch (e: CertificateExpiredException) {
+                return CheckResult(Check.VALIDITY, Status.FAIL, "A certificate in the chain has expired.")
+            } catch (e: CertificateNotYetValidException) {
+                return CheckResult(Check.VALIDITY, Status.FAIL, "A certificate in the chain is not yet valid.")
+            }
+        }
+        return CheckResult(
+            Check.VALIDITY, Status.PASS,
+            "Valid until ${DateFormat.getDateInstance().format(chain.first().notAfter)}."
+        )
+    }
+
+    private fun keyCheck(keyBytes: ByteArray, leaf: X509Certificate): CheckResult {
+        val text = String(keyBytes, Charsets.US_ASCII)
+        val privateKey: PrivateKey? = try {
+            when {
+                text.contains("BEGIN PRIVATE KEY") -> loadPkcs8(keyBytes, leaf.publicKey.algorithm)
+                text.contains("BEGIN ENCRYPTED PRIVATE KEY") ->
+                    return CheckResult(Check.KEY, Status.WARN, "The private key is encrypted — it will be verified when applied.")
+                text.contains("BEGIN RSA PRIVATE KEY") || text.contains("BEGIN EC PRIVATE KEY") ->
+                    return CheckResult(Check.KEY, Status.WARN, "Legacy key format — it will be verified when applied.")
+                else -> null
+            }
+        } catch (e: Exception) {
+            return CheckResult(Check.KEY, Status.WARN, "Could not read the key locally — it will be verified when applied.")
+        }
+        if (privateKey == null) {
+            return CheckResult(Check.KEY, Status.WARN, "Unrecognized key format — it will be verified when applied.")
+        }
+        return if (keyMatchesCert(privateKey, leaf))
+            CheckResult(Check.KEY, Status.PASS, "The private key matches the certificate.")
+        else
+            CheckResult(Check.KEY, Status.FAIL, "The private key does NOT match the certificate.")
+    }
+
+    // --- helpers -------------------------------------------------------------------------------
+
+    private fun parseChain(bytes: ByteArray): List<X509Certificate> {
+        val cf = CertificateFactory.getInstance("X.509")
+        return cf.generateCertificates(ByteArrayInputStream(bytes)).map { it as X509Certificate }
+    }
+
+    private fun certInfo(leaf: X509Certificate) = CertInfo(
+        subject = shortName(leaf.subjectX500Principal.name),
+        issuer = shortName(leaf.issuerX500Principal.name),
+        notAfter = DateFormat.getDateInstance().format(leaf.notAfter),
+        selfSigned = isSelfSigned(leaf),
+    )
+
+    private fun isSelfSigned(c: X509Certificate): Boolean = try {
+        c.verify(c.publicKey)
+        c.subjectX500Principal == c.issuerX500Principal
+    } catch (e: Exception) {
+        false
+    }
+
+    private fun authType(leaf: X509Certificate): String =
+        when (leaf.publicKey.algorithm.uppercase()) {
+            "EC", "ECDSA" -> "EC"
+            else -> leaf.publicKey.algorithm
+        }
+
+    private fun loadPkcs8(pem: ByteArray, certKeyAlgorithm: String): PrivateKey {
+        val der = pemToDer(pem, "PRIVATE KEY")
+        val alg = if (certKeyAlgorithm.equals("EC", true) || certKeyAlgorithm.equals("ECDSA", true))
+            "EC" else certKeyAlgorithm
+        return KeyFactory.getInstance(alg).generatePrivate(PKCS8EncodedKeySpec(der))
+    }
+
+    private fun keyMatchesCert(privateKey: PrivateKey, leaf: X509Certificate): Boolean = try {
+        val sigAlg = when (privateKey.algorithm.uppercase()) {
+            "RSA" -> "SHA256withRSA"
+            "EC", "ECDSA" -> "SHA256withECDSA"
+            else -> return false
+        }
+        val signer = Signature.getInstance(sigAlg)
+        signer.initSign(privateKey)
+        signer.update(NONCE)
+        val sig = signer.sign()
+        val verifier = Signature.getInstance(sigAlg)
+        verifier.initVerify(leaf.publicKey)
+        verifier.update(NONCE)
+        verifier.verify(sig)
+    } catch (e: Exception) {
+        false
+    }
+
+    private fun pemToDer(pem: ByteArray, kind: String): ByteArray {
+        val text = String(pem, Charsets.US_ASCII)
+        val begin = "-----BEGIN $kind-----"
+        val end = "-----END $kind-----"
+        val b = text.indexOf(begin)
+        val e = text.indexOf(end)
+        require(b >= 0 && e > b) { "PEM block not found" }
+        val body = text.substring(b + begin.length, e).replace("\\s".toRegex(), "")
+        return Base64.decode(body, Base64.DEFAULT)
+    }
+
+    private fun looksLikeCertificate(bytes: ByteArray): Boolean =
+        String(bytes, Charsets.US_ASCII).contains("-----BEGIN CERTIFICATE-----")
+
+    private fun looksLikeKey(bytes: ByteArray): Boolean =
+        String(bytes, Charsets.US_ASCII).contains("PRIVATE KEY-----")
+
+    private fun shortName(dn: String): String =
+        dn.split(",").map { it.trim() }.firstOrNull { it.startsWith("CN=", true) }?.substring(3) ?: dn
+
+    private fun fail(message: String, certSlot: ByteArray, keySlot: ByteArray) =
+        ValidationResult(message, emptyList(), false, certSlot, keySlot, null)
+}

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -22,6 +22,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.security.KeyStore;
 import java.text.DecimalFormat;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
@@ -30,6 +31,10 @@ import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Locale;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 public class Util {
 
@@ -451,5 +456,49 @@ public class Util {
             return new String[]{};
         }
         return output.split("\\n");
+    }
+
+    /**
+     * Cached {@link X509TrustManager} backed by the Android OS trust store ("AndroidCAStore"),
+     * which aggregates both the system CAs and the CAs the user manually installed. Built lazily.
+     */
+    private static volatile X509TrustManager sOsTrustManager;
+    private static volatile boolean sOsTrustManagerInitialized = false;
+
+    /**
+     * Returns an {@link X509TrustManager} that validates against the Android OS trust store,
+     * including user-installed CAs. Unlike a {@code TrustManagerFactory.init((KeyStore) null)},
+     * the "AndroidCAStore" keystore exposes user-added certificates on API 24+.
+     *
+     * Used as a fallback so the app can talk to a local Syncthing instance whose HTTPS certificate
+     * was replaced with one signed by a CA the user trusts at the OS level (see
+     * https://github.com/researchxxl/syncthing-android/issues/222).
+     *
+     * @return the OS-backed trust manager, or {@code null} if it could not be built.
+     */
+    public static X509TrustManager getOsTrustManager() {
+        if (!sOsTrustManagerInitialized) {
+            synchronized (Util.class) {
+                if (!sOsTrustManagerInitialized) {
+                    try {
+                        KeyStore caStore = KeyStore.getInstance("AndroidCAStore");
+                        caStore.load(null);
+                        TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                                TrustManagerFactory.getDefaultAlgorithm());
+                        tmf.init(caStore);
+                        for (TrustManager tm : tmf.getTrustManagers()) {
+                            if (tm instanceof X509TrustManager) {
+                                sOsTrustManager = (X509TrustManager) tm;
+                                break;
+                            }
+                        }
+                    } catch (Exception e) {
+                        Log.w(TAG, "getOsTrustManager: Failed to build OS trust manager", e);
+                    }
+                    sOsTrustManagerInitialized = true;
+                }
+            }
+        }
+        return sOsTrustManager;
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
@@ -42,6 +42,7 @@ import java.io.InputStream
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
+import java.net.URL
 import java.security.GeneralSecurityException
 import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
@@ -54,6 +55,14 @@ import androidx.core.net.toUri
 class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChangeListener {
 
     private lateinit var config: ConfigXml
+
+    /**
+     * Web GUI URL pinned to the loopback interface. The WebView only ever talks to the local
+     * Syncthing instance, so we connect on 127.0.0.1 regardless of the configured GUI listen
+     * address (which is 0.0.0.0 when remote access is enabled). This also keeps the WebView within
+     * the loopback domain-config in network_security_config.xml that trusts user-installed CAs.
+     */
+    private lateinit var webGuiUrl: URL
     private var caCertificate: X509Certificate? = null
     private var registeredService: SyncthingService? = null
     private var webView: WebView? = null
@@ -102,6 +111,7 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         super.onCreate(savedInstanceState)
 
         config = loadConfiguration()
+        webGuiUrl = toLoopback(config.webGuiUrl)
         if (!loadCaCertificate()) {
             return
         }
@@ -183,6 +193,23 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         }
     }
 
+    /**
+     * Rewrites the host of the given URL to 127.0.0.1, preserving the scheme and port. The port
+     * comes from the configured GUI listen address; falls back to the default web GUI port.
+     *
+     * Forcing loopback is intentional and security-relevant (mirrors ApiRequest.forceLoopbackHost):
+     * the GUI address is only ever 127.0.0.1 or 0.0.0.0 (the latter includes loopback), so the
+     * instance is always reachable here; it keeps the API key off any routable interface; and it is
+     * the precondition that makes proceeding past SSL_IDMISMATCH (see handleSslError) and trusting
+     * user-installed CAs (loopback domain-config in network_security_config.xml) safe — on loopback
+     * there is no MITM surface. Do not connect to the configured address directly: 0.0.0.0 is not a
+     * valid destination (modern WebView blocks it) and a routable address would break the trust model.
+     */
+    private fun toLoopback(url: URL): URL {
+        val port = if (url.port != -1) url.port else Constants.DEFAULT_WEBGUI_TCP_PORT
+        return URL(url.protocol, "127.0.0.1", port, url.file)
+    }
+
     private fun loadCaCertificate(): Boolean {
         val httpsCertFile: File = Constants.getHttpsCertFile(this)
         if (!httpsCertFile.exists()) {
@@ -242,7 +269,7 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
             0,
             WEB_VIEW_PROXY_EXCLUSIONS,
         )
-        currentWebView.loadUrl(config.webGuiUrl.toString(), createAuthHeaders())
+        currentWebView.loadUrl(webGuiUrl.toString(), createAuthHeaders())
     }
 
     private fun createAuthHeaders(): Map<String, String> {
@@ -256,7 +283,7 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
 
     private fun shouldOpenOutsideWebView(uri: Uri): Boolean {
         val host = uri.host
-        val webGuiHost = config.webGuiUrl.host
+        val webGuiHost = webGuiUrl.host
         if (host != null && host == webGuiHost) {
             return false
         }
@@ -272,6 +299,28 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
     }
 
     private fun handleSslError(handler: SslErrorHandler, error: SslError) {
+        // The WebView only ever connects to the local Syncthing instance over loopback. When the
+        // certificate chain is trusted by the OS (see the loopback domain-config in
+        // network_security_config.xml) but the hostname does not match — e.g. a user-supplied
+        // CA-signed certificate without a 127.0.0.1 SAN — the only remaining error is
+        // SSL_IDMISMATCH. Proceed in that case, mirroring the REST API path which likewise skips
+        // hostname verification for the local connection. Untrusted, expired, and not-yet-valid
+        // certificates are not accepted here; they fall through to self-signed pinning below.
+        //
+        // Checking primaryError == SSL_IDMISMATCH is sufficient to require a trusted chain:
+        // SslError.primaryError returns the highest-severity error present, and SSL_UNTRUSTED
+        // outranks SSL_IDMISMATCH, so an untrusted chain reports SSL_UNTRUSTED here (not
+        // SSL_IDMISMATCH) and is rejected. The explicit expired / not-yet-valid guards then exclude
+        // the remaining date errors that can coexist with a mismatch.
+        if (error.primaryError == SslError.SSL_IDMISMATCH &&
+            !error.hasError(SslError.SSL_EXPIRED) &&
+            !error.hasError(SslError.SSL_NOTYETVALID)
+        ) {
+            handler.proceed()
+            return
+        }
+
+        // Otherwise, fall back to pinning against the local instance's self-signed certificate.
         try {
             val certificate = extractCertificate(error.certificate)
             val ca = caCertificate

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1108,4 +1108,34 @@
     <string name="qs_schedule_label_minutes" tools:ignore="PluralsCandidate">Run for %1$d minutes</string>
     <string name="qs_schedule_disabled">Schedule disabled</string>
     <string name="no_app_to_open_link">No app available to open this link.</string>
+
+    <!-- Custom HTTPS certificate -->
+    <string name="webui_custom_cert_title">Custom HTTPS certificate</string>
+    <string name="webui_custom_cert_summary">Use your own certificate for the local Web UI</string>
+    <string name="custom_cert_explanation">Replace Syncthing\'s built-in self-signed certificate with your own. Pick the certificate (PEM, including the full chain) and its private key, check the validation results, then apply. Syncthing will restart to load the new certificate; if it fails to come back online, the previous certificate is restored automatically.\n\nFor a certificate signed by your own CA, install that CA\'s root certificate on this device first (Settings → Security → Install a CA certificate).</string>
+    <string name="custom_cert_current_title">Current certificate</string>
+    <string name="custom_cert_current_none">No certificate found.</string>
+    <string name="custom_cert_subject">Subject: %1$s</string>
+    <string name="custom_cert_issuer">Issuer: %1$s</string>
+    <string name="custom_cert_expires">Expires: %1$s</string>
+    <string name="custom_cert_self_signed">Self-signed (default)</string>
+    <string name="custom_cert_ca_signed">CA-signed</string>
+    <string name="custom_cert_select_cert">Select certificate (.pem)</string>
+    <string name="custom_cert_select_key">Select private key (.pem)</string>
+    <string name="custom_cert_not_selected">Not selected</string>
+    <string name="custom_cert_apply">Apply certificate</string>
+    <string name="custom_cert_reset_title">Reset to auto-generated certificate</string>
+    <string name="custom_cert_reset_summary">Delete the custom certificate and let Syncthing create a new self-signed one</string>
+    <string name="custom_cert_reset_question">Replace the current certificate with a freshly generated self-signed one?</string>
+    <string name="custom_cert_applying">Applying — restarting Syncthing…</string>
+    <string name="custom_cert_applied">Certificate applied.</string>
+    <string name="custom_cert_applied_pending">Saved. It will take effect the next time Syncthing starts.</string>
+    <string name="custom_cert_failed">Could not apply the certificate: %1$s</string>
+    <string name="custom_cert_reset_done">Reset to a new self-signed certificate.</string>
+    <string name="custom_cert_file_too_large">That file is too large to be a certificate or key.</string>
+    <string name="custom_cert_read_failed">Could not read the selected file.</string>
+    <string name="cert_check_chain">Certificate chain</string>
+    <string name="cert_check_trust">Trusted by this device</string>
+    <string name="cert_check_validity">Validity period</string>
+    <string name="cert_check_key">Private key</string>
 </resources>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -5,9 +5,19 @@
            <certificates src="system" />
        </trust-anchors>
     </base-config>
-    <debug-overrides>
+    <!--
+        The in-app WebView only ever connects to the local Syncthing GUI on the loopback interface
+        (see WebGuiActivity, which pins the WebView to 127.0.0.1). Trust user-installed CAs there so
+        a user-supplied CA-signed HTTPS certificate validates natively, without weakening trust for
+        any other (non-local) connection. See
+        https://github.com/researchxxl/syncthing-android/issues/222
+    -->
+    <domain-config>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">localhost</domain>
         <trust-anchors>
+            <certificates src="system" />
             <certificates src="user" />
         </trust-anchors>
-    </debug-overrides>
+    </domain-config>
 </network-security-config>

--- a/wiki/tips-and-tricks/Use-a-custom-HTTPS-certificate-for-the-Web-GUI.md
+++ b/wiki/tips-and-tricks/Use-a-custom-HTTPS-certificate-for-the-Web-GUI.md
@@ -1,0 +1,90 @@
+### Use your own HTTPS certificate for the Web GUI
+
+By default, Syncthing creates its own **self-signed** certificate for the local Web GUI / API, and
+the app trusts exactly that certificate. If you'd rather use a certificate signed by your own
+Certificate Authority (CA) — for example one issued by a private CA such as
+[Smallstep](https://smallstep.com/), an internal company CA, or a public CA — you can replace the
+built-in certificate and the app will still be able to talk to Syncthing.
+
+This is an advanced, optional setup. The default self-signed certificate is perfectly secure for
+local use, so only do this if you specifically need a CA-signed certificate.
+
+---
+
+### Before you start
+
+You will need:
+
+1. **A certificate and its private key** for the Syncthing Web GUI, in PEM format.
+2. **The full certificate chain** in the certificate file. The file must contain your server
+   (leaf) certificate **followed by any intermediate certificate(s)**, in order. If you only put
+   the leaf certificate in the file, the app (and browsers) can't link it back to your root CA and
+   the connection will be rejected.
+3. **Your root CA installed and trusted on the phone.** Install the root CA under
+   *Android Settings → Security → Encryption & credentials → Install a certificate → CA certificate*
+   (the exact path varies by device). After installing, it appears under your phone's
+   **user-trusted** certificates. The app trusts both the built-in system CAs and the CAs **you**
+   install here.
+
+> The hostname in the certificate does **not** matter. The app always connects to your local
+> Syncthing on the loopback address (`127.0.0.1`), and it does not require the certificate to be
+> issued for `127.0.0.1`. (If you also use Syncthing's "Remote access" feature from other devices,
+> add the relevant hostnames/IPs to the certificate's SAN for those devices — that is independent
+> of the app on the phone.)
+
+---
+
+### Steps
+
+1. In the app, go to **Settings → Import and Export** and **export** your configuration. This
+   creates `config.zip` (by default at
+   `/storage/emulated/0/backups/syncthing/config.zip`). See also
+   [How can I access the config and key files?](Access-Syncthing-config-and-key-files.md).
+2. Open `config.zip` and replace these two files with your own:
+   - `https-cert.pem` — your certificate **including the full chain** (leaf + intermediate(s)).
+   - `https-key.pem` — the matching **private key**.
+
+   Leave everything else (`config.xml`, `cert.pem`, `key.pem`, the database, etc.) unchanged.
+3. Put the updated files back into `config.zip` (keep the same file names and the same archive
+   layout), and copy it back to the export location.
+4. Install your **root CA** on the phone if you haven't already (see *Before you start*, step 3).
+5. In the app, go to **Settings → Import and Export** and **import** the configuration.
+6. Start/restart Syncthing. The app should now connect normally, and the local Web GUI should open
+   using your certificate.
+
+---
+
+### If the app can't connect after the change
+
+If Syncthing is clearly running and syncing, you can open the Web GUI in a normal browser, but the
+**app itself** never finishes loading (it shows your folders/devices but stays stuck, or the API
+seems unreachable), check the following — almost always it's one of these:
+
+- **The root CA isn't installed (or got removed) on the phone.** Re-check
+  *Settings → Security → … → Trusted credentials → User*. Without it, the app cannot verify your
+  certificate.
+- **The certificate file is missing the chain.** `https-cert.pem` must contain the intermediate
+  certificate(s) after the leaf, not just the leaf on its own.
+- **The wrong key was used.** `https-key.pem` must be the private key that matches the leaf
+  certificate in `https-cert.pem`.
+- **The archive layout changed.** When repacking `config.zip`, keep the original file names and
+  structure so the import recognizes the files.
+
+A log line containing `BAD_SIGNATURE` during startup is the classic symptom of a missing/untrusted
+root CA or an incomplete chain.
+
+---
+
+### Good to know (security & privacy)
+
+- The app only ever talks to the Syncthing instance **on the same phone**, over the loopback
+  interface (`127.0.0.1`). Your API key and configuration never leave the device for these calls,
+  even if you enable "Remote access".
+- The app first checks for Syncthing's built-in self-signed certificate. Only if that doesn't match
+  does it fall back to the certificates trusted by Android — including the CA **you** installed.
+  This keeps the default setup unchanged for everyone who doesn't use a custom certificate.
+- Trusting your installed CA for the app is scoped to the **local** connection only; it does not
+  change how Syncthing verifies the other devices you sync with (that uses Syncthing's own
+  device-ID-based security and is unaffected).
+- Reverting is easy: import a fresh/auto-generated configuration, or restore an unmodified
+  `config.zip`, and the app goes back to the default self-signed certificate.

--- a/wiki/tips-and-tricks/Use-a-custom-HTTPS-certificate-for-the-Web-GUI.md
+++ b/wiki/tips-and-tricks/Use-a-custom-HTTPS-certificate-for-the-Web-GUI.md
@@ -34,7 +34,36 @@ You will need:
 
 ---
 
-### Steps
+### Method A — in the app (recommended)
+
+The app has a built-in screen that validates your certificate before applying it and restarts
+Syncthing for you, rolling back automatically if anything goes wrong.
+
+1. Install your **root CA** on the phone if you haven't already (see *Before you start*, step 3).
+2. In the app, go to **Settings → Syncthing Options → Web GUI → Custom HTTPS certificate**.
+3. Tap **Select certificate (.pem)** and choose your certificate file (leaf + full chain), then
+   **Select private key (.pem)** and choose the matching key. (If you pick them in the wrong order,
+   the app sorts it out automatically.)
+4. Review the validation checklist:
+   - **Certificate chain** — is the full chain present?
+   - **Trusted by this device** — will the app accept it? (self-signed, or chains to a CA your
+     device trusts)
+   - **Validity period** — not expired / not yet valid.
+   - **Private key** — does the key match the certificate?
+5. Tap **Apply certificate**. Syncthing restarts with the new certificate. If it doesn't come back
+   online, the previous certificate is restored automatically and you'll see an error.
+
+To go back to the default, use **Reset to auto-generated certificate** on the same screen — Syncthing
+creates a fresh self-signed certificate.
+
+> This screen only appears when the Web UI is served over HTTPS (it is on all modern Android
+> versions).
+
+---
+
+### Method B — manually via config export/import
+
+Use this if you prefer editing files directly.
 
 1. In the app, go to **Settings → Import and Export** and **export** your configuration. This
    creates `config.zip` (by default at
@@ -73,6 +102,9 @@ seems unreachable), check the following — almost always it's one of these:
 A log line containing `BAD_SIGNATURE` during startup is the classic symptom of a missing/untrusted
 root CA or an incomplete chain.
 
+Method A (the in-app screen) catches the first three of these before applying and won't let you
+apply a certificate the app wouldn't be able to trust, so it's the easier path if you're unsure.
+
 ---
 
 ### Good to know (security & privacy)
@@ -86,5 +118,5 @@ root CA or an incomplete chain.
 - Trusting your installed CA for the app is scoped to the **local** connection only; it does not
   change how Syncthing verifies the other devices you sync with (that uses Syncthing's own
   device-ID-based security and is unaffected).
-- Reverting is easy: import a fresh/auto-generated configuration, or restore an unmodified
+- Reverting is easy: use **Reset to auto-generated certificate** (Method A), import an unmodified
   `config.zip`, and the app goes back to the default self-signed certificate.


### PR DESCRIPTION
# Description

Allow users to use custom https certificate for web gui. Closes #222.

# Changes
- Add new preference under Syncthing Opitions for custom certificate
- New preference opens new screen with more information and fucntionality
- Include preference to reset to auto generated certificate

# Screenshots

<img width="250" alt="image" src="https://github.com/user-attachments/assets/33d95d39-4536-49ac-957b-096455f07988" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/4465c034-7f1e-4700-a986-1d510792db0b" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/08e08bc9-1ee7-44a1-9e5e-fcfd86f2ddcd" />

# Demo

https://github.com/user-attachments/assets/8508727e-5251-4b3c-86e7-3c3dc342bb51

