### PR TITLE
fix(WebGuiActivity): fix web gui not loading (fixes #352)

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/WebViewActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/WebViewActivity.java
@@ -163,12 +163,6 @@ public class WebViewActivity extends SyncthingActivity {
         return super.onOptionsItemSelected(item);
     }
 
-    /*
-     * Only the per-instance WebView.onPause()/onResume() are used here. Do NOT reintroduce
-     * pauseTimers()/resumeTimers(): they suspend and resume the Chromium timer shared by *every*
-     * WebView in the process, so pausing here and being destroyed before resuming leaves the whole
-     * process suspended and breaks the next WebView opened by any other activity.
-     */
     @Override
     public void onPause() {
         mWebView.onPause();

--- a/app/src/main/java/com/nutomic/syncthingandroid/activities/WebViewActivity.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/activities/WebViewActivity.java
@@ -163,17 +163,21 @@ public class WebViewActivity extends SyncthingActivity {
         return super.onOptionsItemSelected(item);
     }
 
+    /*
+     * Only the per-instance WebView.onPause()/onResume() are used here. Do NOT reintroduce
+     * pauseTimers()/resumeTimers(): they suspend and resume the Chromium timer shared by *every*
+     * WebView in the process, so pausing here and being destroyed before resuming leaves the whole
+     * process suspended and breaks the next WebView opened by any other activity.
+     */
     @Override
     public void onPause() {
         mWebView.onPause();
-        mWebView.pauseTimers();
         super.onPause();
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        mWebView.resumeTimers();
         mWebView.onResume();
     }
 

--- a/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
@@ -169,12 +169,6 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         loadWebGuiIfNeeded()
     }
 
-    // Only the per-instance WebView.onPause()/onResume() are used here. Do NOT reintroduce
-    // pauseTimers()/resumeTimers(): despite being instance methods they suspend and resume the
-    // Chromium timer shared by *every* WebView in the process. The WebView is created by the
-    // AndroidView factory during composition, which runs after onResume() has already returned, so
-    // webView is still null there and onResume() could never resume what a previous instance
-    // paused — every WebView opened afterwards then stalls mid-load.
     override fun onPause() {
         webView?.onPause()
         super.onPause()

--- a/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
@@ -5,33 +5,26 @@ import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.net.Proxy
 import android.net.Uri
 import android.net.http.SslCertificate
 import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
 import android.os.IBinder
-import android.os.Looper
 import android.os.Parcelable
 import android.util.ArrayMap
 import android.util.Base64
 import android.util.Log
-import android.view.ViewGroup
-import android.webkit.RenderProcessGoneDetail
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -74,32 +67,10 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
     private var caCertificate: X509Certificate? = null
     private var registeredService: SyncthingService? = null
     private var webView: WebView? = null
+    private var webGuiLoadStarted = false
     private var serviceActive = false
-
-    /**
-     * True once a load has been issued and has not failed. Cleared again by [onLoadFailed] so the
-     * next State.ACTIVE event — or the Retry button — reloads instead of leaving the screen dead.
-     */
-    private var loadIssued = false
-
-    /**
-     * Set by the error callbacks and cleared by onPageStarted. onPageFinished also runs for a
-     * failed main frame load (WebView renders its own error page), so it must not report success
-     * when this is set.
-     */
-    private var mainFrameFailed = false
-
-    /** The dead WebView after a render process crash; it is replaced on the next retry. */
-    private var webViewNeedsRecreate = false
-
-    private var loadState by mutableStateOf<WebGuiLoadState>(WebGuiLoadState.Loading)
-    private var webViewGeneration by mutableStateOf(0)
-
-    private val mainHandler = Handler(Looper.getMainLooper())
-    private val loadTimeout = Runnable {
-        Log.w(TAG, "Web GUI did not load within ${LOAD_TIMEOUT_MS} ms")
-        onLoadFailed(getString(R.string.web_gui_load_timeout))
-    }
+    private var webGuiLoading by mutableStateOf(true)
+    private var webGuiLoadError by mutableStateOf<String?>(null)
 
     private val webViewClient = object : WebViewClient() {
         override fun onReceivedSslError(
@@ -121,55 +92,23 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean =
             shouldOpenOutsideWebView(url.toUri())
 
-        override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
-            mainFrameFailed = false
-        }
-
-        // Every failure path below must clear the overlay. Reporting only onPageFinished — as this
-        // screen originally did — turns any load failure into an endless spinner with no way out.
+        // Only the initial load matters here: webGuiLoading is true until the GUI came up once.
+        // Without this the loading view is only ever dismissed by onPageFinished, so a failed load
+        // leaves the user on an endless spinner with nothing to report.
         override fun onReceivedError(
             view: WebView,
             request: WebResourceRequest,
             error: WebResourceError,
         ) {
-            if (!request.isForMainFrame) {
+            if (!request.isForMainFrame || !webGuiLoading) {
                 return
             }
             Log.w(TAG, "Web GUI load failed: ${error.errorCode} ${error.description}")
-            onLoadFailed("${error.description} (${error.errorCode})")
-        }
-
-        override fun onReceivedHttpError(
-            view: WebView,
-            request: WebResourceRequest,
-            errorResponse: WebResourceResponse,
-        ) {
-            if (!request.isForMainFrame) {
-                return
-            }
-            Log.w(TAG, "Web GUI returned HTTP ${errorResponse.statusCode}")
-            onLoadFailed(getString(R.string.web_gui_load_failed_http, errorResponse.statusCode))
-        }
-
-        // Returning false here lets the system kill the app process. Take the crash instead and
-        // offer a retry; the WebView is unusable afterwards, so it is replaced before reloading.
-        @RequiresApi(Build.VERSION_CODES.O)
-        override fun onRenderProcessGone(
-            view: WebView,
-            detail: RenderProcessGoneDetail,
-        ): Boolean {
-            Log.w(TAG, "WebView render process gone, didCrash=${detail.didCrash()}")
-            webViewNeedsRecreate = true
-            onLoadFailed(getString(R.string.web_gui_load_failed_renderer))
-            return true
+            webGuiLoadError = "${error.description} (${error.errorCode})"
         }
 
         override fun onPageFinished(view: WebView, url: String) {
-            if (mainFrameFailed) {
-                return
-            }
-            cancelLoadTimeout()
-            loadState = WebGuiLoadState.Loaded
+            webGuiLoading = false
         }
     }
 
@@ -194,26 +133,27 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
             return
         }
 
-        // Created eagerly rather than from the AndroidView factory: the factory runs during
-        // composition, i.e. after onCreate *and* onResume have returned, which means every
-        // lifecycle callback would see a null WebView on the way in.
-        webView = createWebView(this)
-
         setContent {
             ApplicationTheme {
                 WebGuiScreen(
-                    state = loadState,
+                    loading = webGuiLoading,
+                    error = webGuiLoadError,
                     onNavigateBack = { finish() },
-                    onRetry = ::retryLoad,
-                    webViewKey = webViewGeneration,
-                    webViewFactory = { detachedWebView() },
+                    webViewFactory = { context ->
+                        createWebView(context).also {
+                            webView = it
+                            // The WebView is created lazily during composition, which may run
+                            // after the service already reported ACTIVE. Attempt the load here so
+                            // we don't miss that initial state and stay stuck on the spinner.
+                            loadWebGuiIfNeeded()
+                        }
+                    },
                 )
             }
         }
 
         startSyncthingService()
         onBackPressedDispatcher.addCallback(this, backPressedCallback)
-        scheduleLoadTimeout()
     }
 
     override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
@@ -234,8 +174,10 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
 
     // Only the per-instance WebView.onPause()/onResume() are used here. Do NOT reintroduce
     // pauseTimers()/resumeTimers(): despite being instance methods they suspend and resume the
-    // Chromium timer shared by *every* WebView in the process, so one screen pausing them stalls
-    // page loads in every WebView the app opens afterwards.
+    // Chromium timer shared by *every* WebView in the process. The WebView is created by the
+    // AndroidView factory during composition, which runs after onResume() has already returned, so
+    // webView is still null there and onResume() could never resume what a previous instance
+    // paused — every WebView opened afterwards then stalls mid-load.
     override fun onPause() {
         webView?.onPause()
         super.onPause()
@@ -247,14 +189,8 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
     }
 
     override fun onDestroy() {
-        cancelLoadTimeout()
         unregisterServiceListener()
-        // WebView.destroy() requires the view to be detached first, otherwise it can keep
-        // rendering into a torn-down surface.
-        webView?.let {
-            (it.parent as? ViewGroup)?.removeView(it)
-            it.destroy()
-        }
+        webView?.destroy()
         webView = null
         super.onDestroy()
     }
@@ -337,66 +273,17 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         registeredService = null
     }
 
-    /**
-     * Hands the WebView to Compose. [WebGuiScreen] re-parents it, so it must not still be attached
-     * to the container of a previous [androidx.compose.ui.viewinterop.AndroidView] node.
-     */
-    private fun detachedWebView(): WebView {
-        val currentWebView = webView ?: createWebView(this).also { webView = it }
-        (currentWebView.parent as? ViewGroup)?.removeView(currentWebView)
-        return currentWebView
-    }
-
-    /** Replaces a WebView whose render process died; the old one can never be reused. */
-    private fun recreateWebView() {
-        val dead = webView
-        (dead?.parent as? ViewGroup)?.removeView(dead)
-        webView = createWebView(this)
-        webViewNeedsRecreate = false
-        webViewGeneration++
-        dead?.destroy()
-    }
-
-    private fun retryLoad() {
-        if (webViewNeedsRecreate) {
-            recreateWebView()
-        }
-        loadIssued = false
-        mainFrameFailed = false
-        loadState = WebGuiLoadState.Loading
-        scheduleLoadTimeout()
-        loadWebGuiIfNeeded()
-    }
-
-    private fun onLoadFailed(detail: String?) {
-        cancelLoadTimeout()
-        mainFrameFailed = true
-        // Allow the next State.ACTIVE event (including the replay on every onResume) to reload.
-        loadIssued = false
-        loadState = WebGuiLoadState.Failed(detail)
-    }
-
-    private fun scheduleLoadTimeout() {
-        cancelLoadTimeout()
-        mainHandler.postDelayed(loadTimeout, LOAD_TIMEOUT_MS)
-    }
-
-    private fun cancelLoadTimeout() = mainHandler.removeCallbacks(loadTimeout)
-
     private fun loadWebGuiIfNeeded() {
         val currentWebView = webView
         if (currentWebView == null) {
             Log.v(TAG, "loadWebGuiIfNeeded: Skipped event due to webView == null")
             return
         }
-        if (!serviceActive || loadIssued || webViewNeedsRecreate) {
+        if (!serviceActive || webGuiLoadStarted || currentWebView.url != null) {
             return
         }
 
-        loadIssued = true
-        mainFrameFailed = false
-        loadState = WebGuiLoadState.Loading
-        scheduleLoadTimeout()
+        webGuiLoadStarted = true
         currentWebView.stopLoading()
         setWebViewProxy(
             currentWebView.context.applicationContext,
@@ -487,12 +374,6 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
     companion object {
         private const val TAG = "WebGuiActivity"
         private const val WEB_VIEW_PROXY_EXCLUSIONS = "localhost|0.0.0.0|127.*|[::1]"
-
-        /**
-         * How long the overlay may stay up before the screen gives up and offers a retry. Generous,
-         * because it also covers syncthing still starting up (State.ACTIVE not reached yet).
-         */
-        private const val LOAD_TIMEOUT_MS = 60_000L
 
         /**
          * Set WebView proxy and sites that are not retrieved using proxy.

--- a/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
@@ -5,25 +5,33 @@ import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import android.net.Proxy
 import android.net.Uri
 import android.net.http.SslCertificate
 import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.os.Parcelable
 import android.util.ArrayMap
 import android.util.Base64
 import android.util.Log
+import android.view.ViewGroup
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.SslErrorHandler
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -66,9 +74,32 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
     private var caCertificate: X509Certificate? = null
     private var registeredService: SyncthingService? = null
     private var webView: WebView? = null
-    private var webGuiLoadStarted = false
     private var serviceActive = false
-    private var webGuiLoading by mutableStateOf(true)
+
+    /**
+     * True once a load has been issued and has not failed. Cleared again by [onLoadFailed] so the
+     * next State.ACTIVE event — or the Retry button — reloads instead of leaving the screen dead.
+     */
+    private var loadIssued = false
+
+    /**
+     * Set by the error callbacks and cleared by onPageStarted. onPageFinished also runs for a
+     * failed main frame load (WebView renders its own error page), so it must not report success
+     * when this is set.
+     */
+    private var mainFrameFailed = false
+
+    /** The dead WebView after a render process crash; it is replaced on the next retry. */
+    private var webViewNeedsRecreate = false
+
+    private var loadState by mutableStateOf<WebGuiLoadState>(WebGuiLoadState.Loading)
+    private var webViewGeneration by mutableStateOf(0)
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val loadTimeout = Runnable {
+        Log.w(TAG, "Web GUI did not load within ${LOAD_TIMEOUT_MS} ms")
+        onLoadFailed(getString(R.string.web_gui_load_timeout))
+    }
 
     private val webViewClient = object : WebViewClient() {
         override fun onReceivedSslError(
@@ -90,8 +121,55 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean =
             shouldOpenOutsideWebView(url.toUri())
 
+        override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+            mainFrameFailed = false
+        }
+
+        // Every failure path below must clear the overlay. Reporting only onPageFinished — as this
+        // screen originally did — turns any load failure into an endless spinner with no way out.
+        override fun onReceivedError(
+            view: WebView,
+            request: WebResourceRequest,
+            error: WebResourceError,
+        ) {
+            if (!request.isForMainFrame) {
+                return
+            }
+            Log.w(TAG, "Web GUI load failed: ${error.errorCode} ${error.description}")
+            onLoadFailed("${error.description} (${error.errorCode})")
+        }
+
+        override fun onReceivedHttpError(
+            view: WebView,
+            request: WebResourceRequest,
+            errorResponse: WebResourceResponse,
+        ) {
+            if (!request.isForMainFrame) {
+                return
+            }
+            Log.w(TAG, "Web GUI returned HTTP ${errorResponse.statusCode}")
+            onLoadFailed(getString(R.string.web_gui_load_failed_http, errorResponse.statusCode))
+        }
+
+        // Returning false here lets the system kill the app process. Take the crash instead and
+        // offer a retry; the WebView is unusable afterwards, so it is replaced before reloading.
+        @RequiresApi(Build.VERSION_CODES.O)
+        override fun onRenderProcessGone(
+            view: WebView,
+            detail: RenderProcessGoneDetail,
+        ): Boolean {
+            Log.w(TAG, "WebView render process gone, didCrash=${detail.didCrash()}")
+            webViewNeedsRecreate = true
+            onLoadFailed(getString(R.string.web_gui_load_failed_renderer))
+            return true
+        }
+
         override fun onPageFinished(view: WebView, url: String) {
-            webGuiLoading = false
+            if (mainFrameFailed) {
+                return
+            }
+            cancelLoadTimeout()
+            loadState = WebGuiLoadState.Loaded
         }
     }
 
@@ -116,26 +194,26 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
             return
         }
 
+        // Created eagerly rather than from the AndroidView factory: the factory runs during
+        // composition, i.e. after onCreate *and* onResume have returned, which means every
+        // lifecycle callback would see a null WebView on the way in.
+        webView = createWebView(this)
+
         setContent {
             ApplicationTheme {
                 WebGuiScreen(
-                    loading = webGuiLoading,
+                    state = loadState,
                     onNavigateBack = { finish() },
-                    webViewFactory = { context ->
-                        createWebView(context).also {
-                            webView = it
-                            // The WebView is created lazily during composition, which may run
-                            // after the service already reported ACTIVE. Attempt the load here so
-                            // we don't miss that initial state and stay stuck on the spinner.
-                            loadWebGuiIfNeeded()
-                        }
-                    },
+                    onRetry = ::retryLoad,
+                    webViewKey = webViewGeneration,
+                    webViewFactory = { detachedWebView() },
                 )
             }
         }
 
         startSyncthingService()
         onBackPressedDispatcher.addCallback(this, backPressedCallback)
+        scheduleLoadTimeout()
     }
 
     override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
@@ -154,21 +232,29 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         loadWebGuiIfNeeded()
     }
 
+    // Only the per-instance WebView.onPause()/onResume() are used here. Do NOT reintroduce
+    // pauseTimers()/resumeTimers(): despite being instance methods they suspend and resume the
+    // Chromium timer shared by *every* WebView in the process, so one screen pausing them stalls
+    // page loads in every WebView the app opens afterwards.
     override fun onPause() {
         webView?.onPause()
-        webView?.pauseTimers()
         super.onPause()
     }
 
     override fun onResume() {
         super.onResume()
-        webView?.resumeTimers()
         webView?.onResume()
     }
 
     override fun onDestroy() {
+        cancelLoadTimeout()
         unregisterServiceListener()
-        webView?.destroy()
+        // WebView.destroy() requires the view to be detached first, otherwise it can keep
+        // rendering into a torn-down surface.
+        webView?.let {
+            (it.parent as? ViewGroup)?.removeView(it)
+            it.destroy()
+        }
         webView = null
         super.onDestroy()
     }
@@ -251,17 +337,66 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         registeredService = null
     }
 
+    /**
+     * Hands the WebView to Compose. [WebGuiScreen] re-parents it, so it must not still be attached
+     * to the container of a previous [androidx.compose.ui.viewinterop.AndroidView] node.
+     */
+    private fun detachedWebView(): WebView {
+        val currentWebView = webView ?: createWebView(this).also { webView = it }
+        (currentWebView.parent as? ViewGroup)?.removeView(currentWebView)
+        return currentWebView
+    }
+
+    /** Replaces a WebView whose render process died; the old one can never be reused. */
+    private fun recreateWebView() {
+        val dead = webView
+        (dead?.parent as? ViewGroup)?.removeView(dead)
+        webView = createWebView(this)
+        webViewNeedsRecreate = false
+        webViewGeneration++
+        dead?.destroy()
+    }
+
+    private fun retryLoad() {
+        if (webViewNeedsRecreate) {
+            recreateWebView()
+        }
+        loadIssued = false
+        mainFrameFailed = false
+        loadState = WebGuiLoadState.Loading
+        scheduleLoadTimeout()
+        loadWebGuiIfNeeded()
+    }
+
+    private fun onLoadFailed(detail: String?) {
+        cancelLoadTimeout()
+        mainFrameFailed = true
+        // Allow the next State.ACTIVE event (including the replay on every onResume) to reload.
+        loadIssued = false
+        loadState = WebGuiLoadState.Failed(detail)
+    }
+
+    private fun scheduleLoadTimeout() {
+        cancelLoadTimeout()
+        mainHandler.postDelayed(loadTimeout, LOAD_TIMEOUT_MS)
+    }
+
+    private fun cancelLoadTimeout() = mainHandler.removeCallbacks(loadTimeout)
+
     private fun loadWebGuiIfNeeded() {
         val currentWebView = webView
         if (currentWebView == null) {
             Log.v(TAG, "loadWebGuiIfNeeded: Skipped event due to webView == null")
             return
         }
-        if (!serviceActive || webGuiLoadStarted || currentWebView.url != null) {
+        if (!serviceActive || loadIssued || webViewNeedsRecreate) {
             return
         }
 
-        webGuiLoadStarted = true
+        loadIssued = true
+        mainFrameFailed = false
+        loadState = WebGuiLoadState.Loading
+        scheduleLoadTimeout()
         currentWebView.stopLoading()
         setWebViewProxy(
             currentWebView.context.applicationContext,
@@ -352,6 +487,12 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
     companion object {
         private const val TAG = "WebGuiActivity"
         private const val WEB_VIEW_PROXY_EXCLUSIONS = "localhost|0.0.0.0|127.*|[::1]"
+
+        /**
+         * How long the overlay may stay up before the screen gives up and offers a retry. Generous,
+         * because it also covers syncthing still starting up (State.ACTIVE not reached yet).
+         */
+        private const val LOAD_TIMEOUT_MS = 60_000L
 
         /**
          * Set WebView proxy and sites that are not retrieved using proxy.

--- a/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiActivity.kt
@@ -92,9 +92,6 @@ class WebGuiActivity : SyncthingActivity(), SyncthingService.OnServiceStateChang
         override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean =
             shouldOpenOutsideWebView(url.toUri())
 
-        // Only the initial load matters here: webGuiLoading is true until the GUI came up once.
-        // Without this the loading view is only ever dismissed by onPageFinished, so a failed load
-        // leaves the user on an endless spinner with nothing to report.
         override fun onReceivedError(
             view: WebView,
             request: WebResourceRequest,

--- a/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiScreen.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiScreen.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -21,7 +19,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -30,30 +27,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.nutomic.syncthingandroid.R
 
-/**
- * What the Web GUI screen shows on top of the WebView. The WebView itself is always present; these
- * states only control the overlay, so a failed load can never leave the user staring at a spinner.
- */
-internal sealed interface WebGuiLoadState {
-    data object Loading : WebGuiLoadState
-
-    data object Loaded : WebGuiLoadState
-
-    /** [detail] is a short technical cause shown under the generic message, if one is known. */
-    data class Failed(val detail: String?) : WebGuiLoadState
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun WebGuiScreen(
-    state: WebGuiLoadState,
+    loading: Boolean,
+    error: String?,
     onNavigateBack: () -> Unit,
-    onRetry: () -> Unit,
-    /**
-     * Changing this discards the current WebView and asks [webViewFactory] for a new one. Needed
-     * after the render process dies, because that WebView can never be used again.
-     */
-    webViewKey: Any,
     webViewFactory: (Context) -> WebView,
 ) {
     Scaffold(
@@ -77,86 +56,51 @@ internal fun WebGuiScreen(
                 .padding(paddingValues),
         ) {
             Box(Modifier.fillMaxSize()) {
-                key(webViewKey) {
-                    AndroidView(
-                        factory = webViewFactory,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
+                AndroidView(
+                    factory = webViewFactory,
+                    modifier = Modifier.fillMaxSize(),
+                )
 
-                when (state) {
-                    WebGuiLoadState.Loaded -> Unit
-                    WebGuiLoadState.Loading -> LoadingOverlay()
-                    is WebGuiLoadState.Failed -> FailedOverlay(state.detail, onRetry)
+                // Kept up on failure too, so the WebView's own error page does not replace the
+                // message asking the user for a log.
+                if (loading || error != null) {
+                    Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color = MaterialTheme.colorScheme.surface,
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(32.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center,
+                        ) {
+                            if (error == null) {
+                                CircularProgressIndicator()
+                                Text(
+                                    text = stringResource(R.string.web_gui_loading),
+                                    modifier = Modifier.padding(top = 16.dp),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            } else {
+                                Text(
+                                    text = stringResource(R.string.web_gui_load_failed),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    textAlign = TextAlign.Center,
+                                )
+                                Text(
+                                    text = error,
+                                    modifier = Modifier.padding(top = 16.dp),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    textAlign = TextAlign.Center,
+                                )
+                            }
+                        }
+                    }
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun LoadingOverlay() {
-    Overlay {
-        CircularProgressIndicator()
-        Text(
-            text = stringResource(R.string.web_gui_loading),
-            modifier = Modifier.padding(top = 16.dp),
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-@Composable
-private fun FailedOverlay(detail: String?, onRetry: () -> Unit) {
-    Overlay {
-        Icon(
-            imageVector = Icons.Default.Warning,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.error,
-        )
-        Text(
-            text = stringResource(R.string.web_gui_load_failed),
-            modifier = Modifier.padding(top = 16.dp),
-            style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center,
-        )
-        if (detail != null) {
-            Text(
-                text = detail,
-                modifier = Modifier.padding(top = 8.dp),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-            )
-        }
-        Button(
-            onClick = onRetry,
-            modifier = Modifier.padding(top = 24.dp),
-        ) {
-            Text(stringResource(R.string.retry))
-        }
-    }
-}
-
-/**
- * Opaque full-size cover so the WebView underneath (blank, or showing its own error page) never
- * shows through.
- */
-@Composable
-private fun Overlay(content: @Composable () -> Unit) {
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.surface,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            content()
         }
     }
 }

--- a/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiScreen.kt
+++ b/app/src/main/java/com/nutomic/syncthingandroid/webgui/WebGuiScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -19,18 +21,39 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.nutomic.syncthingandroid.R
 
+/**
+ * What the Web GUI screen shows on top of the WebView. The WebView itself is always present; these
+ * states only control the overlay, so a failed load can never leave the user staring at a spinner.
+ */
+internal sealed interface WebGuiLoadState {
+    data object Loading : WebGuiLoadState
+
+    data object Loaded : WebGuiLoadState
+
+    /** [detail] is a short technical cause shown under the generic message, if one is known. */
+    data class Failed(val detail: String?) : WebGuiLoadState
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun WebGuiScreen(
-    loading: Boolean,
+    state: WebGuiLoadState,
     onNavigateBack: () -> Unit,
+    onRetry: () -> Unit,
+    /**
+     * Changing this discards the current WebView and asks [webViewFactory] for a new one. Needed
+     * after the render process dies, because that WebView can never be used again.
+     */
+    webViewKey: Any,
     webViewFactory: (Context) -> WebView,
 ) {
     Scaffold(
@@ -54,34 +77,86 @@ internal fun WebGuiScreen(
                 .padding(paddingValues),
         ) {
             Box(Modifier.fillMaxSize()) {
-                AndroidView(
-                    factory = webViewFactory,
-                    modifier = Modifier.fillMaxSize(),
-                )
-
-                if (loading) {
-                    Surface(
+                key(webViewKey) {
+                    AndroidView(
+                        factory = webViewFactory,
                         modifier = Modifier.fillMaxSize(),
-                        color = MaterialTheme.colorScheme.surface,
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(32.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.Center,
-                        ) {
-                            CircularProgressIndicator()
-                            Text(
-                                text = stringResource(R.string.web_gui_loading),
-                                modifier = Modifier.padding(top = 16.dp),
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
+                    )
+                }
+
+                when (state) {
+                    WebGuiLoadState.Loaded -> Unit
+                    WebGuiLoadState.Loading -> LoadingOverlay()
+                    is WebGuiLoadState.Failed -> FailedOverlay(state.detail, onRetry)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun LoadingOverlay() {
+    Overlay {
+        CircularProgressIndicator()
+        Text(
+            text = stringResource(R.string.web_gui_loading),
+            modifier = Modifier.padding(top = 16.dp),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun FailedOverlay(detail: String?, onRetry: () -> Unit) {
+    Overlay {
+        Icon(
+            imageVector = Icons.Default.Warning,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.error,
+        )
+        Text(
+            text = stringResource(R.string.web_gui_load_failed),
+            modifier = Modifier.padding(top = 16.dp),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+        )
+        if (detail != null) {
+            Text(
+                text = detail,
+                modifier = Modifier.padding(top = 8.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+        Button(
+            onClick = onRetry,
+            modifier = Modifier.padding(top = 24.dp),
+        ) {
+            Text(stringResource(R.string.retry))
+        }
+    }
+}
+
+/**
+ * Opaque full-size cover so the WebView underneath (blank, or showing its own error page) never
+ * shows through.
+ */
+@Composable
+private fun Overlay(content: @Composable () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            content()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -427,6 +427,21 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Waiting for GUI</string>
 
+    <!-- Shown in WebGuiActivity when the web gui could not be loaded -->
+    <string name="web_gui_load_failed">Couldn\'t load the Web GUI</string>
+
+    <!-- Reason shown in WebGuiActivity when the web gui did not respond in time -->
+    <string name="web_gui_load_timeout">The local Syncthing instance did not respond.</string>
+
+    <!-- Reason shown in WebGuiActivity when the web gui answered with an HTTP error, %1$d is the status code -->
+    <string name="web_gui_load_failed_http">The Web GUI answered with HTTP %1$d.</string>
+
+    <!-- Reason shown in WebGuiActivity when the WebView render process died -->
+    <string name="web_gui_load_failed_renderer">The browser engine stopped unexpectedly.</string>
+
+    <!-- Button that reloads the web gui after a failed load -->
+    <string name="retry">Retry</string>
+
     <!-- WebViewActivity -->
 
     <!-- Dialog title displayed when an invalid ssl certificate was found -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -427,20 +427,9 @@
     <!-- Text for WebGuiActivity loading view -->
     <string name="web_gui_loading">Waiting for GUI</string>
 
-    <!-- Shown in WebGuiActivity when the web gui could not be loaded -->
-    <string name="web_gui_load_failed">Couldn\'t load the Web GUI</string>
-
-    <!-- Reason shown in WebGuiActivity when the web gui did not respond in time -->
-    <string name="web_gui_load_timeout">The local Syncthing instance did not respond.</string>
-
-    <!-- Reason shown in WebGuiActivity when the web gui answered with an HTTP error, %1$d is the status code -->
-    <string name="web_gui_load_failed_http">The Web GUI answered with HTTP %1$d.</string>
-
-    <!-- Reason shown in WebGuiActivity when the WebView render process died -->
-    <string name="web_gui_load_failed_renderer">The browser engine stopped unexpectedly.</string>
-
-    <!-- Button that reloads the web gui after a failed load -->
-    <string name="retry">Retry</string>
+    <!-- Shown in WebGuiActivity when the web gui could not be loaded. The technical cause is shown
+         below it and written to the log. -->
+    <string name="web_gui_load_failed">Couldn\'t load the Web GUI. Please capture a log and report this.</string>
 
     <!-- WebViewActivity -->
 


### PR DESCRIPTION
# Description
Fixes #352.

Opening the Web GUI from the drawer often showed "Waiting for GUI" forever and never switched to the
web UI. It reproduces 100% of the time: open the Web GUI once, go back, open it again — the second
and every later open in the same app process hangs. `SyncthingService` is a foreground service so
the process practically never dies, which is why for most users the Web GUI simply stops working
after the first use, and why it looked random to anyone testing from a cold start.

The cause is `WebView.pauseTimers()` in `WebGuiActivity.onPause()`. Despite being an instance method
it suspends the Chromium timer shared by *every* WebView in the process, and the matching
`resumeTimers()` in `onResume()` never ran: since the Compose migration (#296) the WebView is created
by the `AndroidView` factory during composition, which happens *after* `onResume()` has already
returned, so `webView` is still `null` there. Nothing else in the process resumes the timers, so the
next WebView is created into a suspended process, its page load never completes, `onPageFinished`
never fires and the loading view stays up forever. The pre-Compose screen was immune by accident: its
WebView was inflated in `onCreate`, so `resumeTimers()` in `onResume` always ran.

`WebViewActivity` (Report issue) has the same `pauseTimers()`/`resumeTimers()` pair. It resumes
correctly for itself, but if it is paused and then destroyed it leaves the process suspended and
breaks the next Web GUI the same way, so fixing only `WebGuiActivity` would not have been enough.

On top of the timer fix there is one small addition: `onPageFinished` was the only thing that ever
dismissed the loading view, so *any* load failure looked exactly like this bug — an endless spinner
with nothing for the user to report. `onReceivedError` for the main frame now shows the error and
writes it to the log, so a broken Syncthing is distinguishable from a broken screen and there is
something to attach to a bug report.

Verified on an emulator (API 36 / WebView 133) and on a physical device (Realme RMX3771, Android 15 /
WebView 151), where the hang was reproduced on the shipped release build first and then confirmed
fixed. `lintDebug` reports no issues.


# Changes

* Remove the process-global `WebView.pauseTimers()` / `resumeTimers()` calls from `WebGuiActivity`
  and `WebViewActivity`; the per-instance `WebView.onPause()` / `onResume()` are what these screens
  actually want. Both carry a comment explaining why they must not come back.
* Show the load error instead of the spinner when the initial main-frame load fails, and log it, so
  the user has something to capture and report.


# Screenshots

_Newly introduced error page_

<img width="250" alt="02-after-load-failure-message-dark" src="https://github.com/user-attachments/assets/deb05a95-722c-45a3-a1df-041a60c63559" />