### PR TITLE
fix(root): escape values written into the root shell

### DIFF
--- a/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/service/SyncthingRunnable.java
@@ -448,15 +448,28 @@ public class SyncthingRunnable implements Runnable {
             // Even with --preserve-environment the environment gets messed up.
             // We therefore start a root shell, and set all the environment variables manually.
             DataOutputStream suOut = new DataOutputStream(process.getOutputStream());
+            // Every value written into this shell must be quoted. The environment may contain
+            // user supplied entries (Constants.PREF_ENVIRONMENT_VARIABLES), and an unquoted value
+            // would be expanded by the shell - meaning e.g. "$(...)" executes as root.
             for (Map.Entry<String, String> entry : env.entrySet()) {
-                suOut.writeBytes(String.format("export %s=\"%s\"\n", entry.getKey(), entry.getValue()));
+                if (!Util.isValidEnvVarName(entry.getKey())) {
+                    // A name cannot be quoted, so reject it rather than let it inject commands.
+                    Log.w(TAG, "Skipping environment variable with invalid name [" + entry.getKey() + "]");
+                    continue;
+                }
+                suOut.writeBytes(String.format("export %s=%s\n",
+                        entry.getKey(), Util.shellQuote(entry.getValue())));
             }
             suOut.flush();
             // Exec will replace the su process image by Syncthing as execlp in C does.
             // Without using exec, the process will drop to the root shell as soon as Syncthing terminates like a normal shell does.
             // If we did not use exec, we would wait infinitely for the process to terminate (ret = process.waitFor(); in run()).
             // With exec the whole process terminates when Syncthing exits.
-            suOut.writeBytes("exec " + TextUtils.join(" ", mCommand) + "\n");
+            StringBuilder execLine = new StringBuilder("exec");
+            for (String arg : mCommand) {
+                execLine.append(' ').append(Util.shellQuote(arg));
+            }
+            suOut.writeBytes(execLine.append('\n').toString());
             suOut.flush();
             return process;
         } else {

--- a/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
+++ b/app/src/main/java/com/nutomic/syncthingandroid/util/Util.java
@@ -115,12 +115,13 @@ public class Util {
 
         // Get private app's "files" dir residing in "/data/data/[packageName]".
         String dir = context.getFilesDir().getAbsolutePath();
-        String cmd = "chown -R " + appInfo.uid + ":" + appInfo.uid + " " + dir + "; ";
+        String quotedDir = shellQuote(dir);
+        String cmd = "chown -R " + appInfo.uid + ":" + appInfo.uid + " " + quotedDir + "; ";
         // Running Syncthing as root might change a file's or directories type in terms of SELinux.
         // Leaving them as they are, the Android service won't be able to access them.
         // At least for those files residing in an application's data folder.
         // Simply reverting the type to its default should do the trick.
-        cmd += "restorecon -R " + dir + "\n";
+        cmd += "restorecon -R " + quotedDir + "\n";
         Log.d(TAG, "Running: '" + cmd);
         int exitCode = runShellCommand(cmd, true);
         if (exitCode == 0) {
@@ -144,8 +145,11 @@ public class Util {
         }
 
         // Write permission test file.
+        // The folder path is chosen by the user, so it must be quoted - it may contain characters
+        // the shell would otherwise expand, and this command runs as root when root mode is on.
         String touchFile = absoluteFolderPath + "/" + TOUCH_FILE_NAME;
-        int exitCode = runShellCommand("echo \"\" > \"" + touchFile + "\"\n", useRoot);
+        String quotedTouchFile = shellQuote(touchFile);
+        int exitCode = runShellCommand("echo \"\" > " + quotedTouchFile + "\n", useRoot);
         if (exitCode != 0) {
             String error;
             switch (exitCode) {
@@ -164,9 +168,54 @@ public class Util {
         Log.i(TAG, "Successfully wrote test file '" + touchFile + "'");
 
         // Remove test file.
-        if (runShellCommand("rm \"" + touchFile + "\"\n", useRoot) != 0) {
+        if (runShellCommand("rm " + quotedTouchFile + "\n", useRoot) != 0) {
             // This is very unlikely to happen, so we have less error handling.
             Log.i(TAG, "Failed to remove test file");
+        }
+        return true;
+    }
+
+    /**
+     * Quotes a string for safe use as a single argument in a POSIX shell command line.
+     *
+     * Everything is wrapped in single quotes, within which the shell performs no expansion at all,
+     * so '$', '`', '"', '\' and whitespace are passed through literally. An embedded single quote
+     * cannot be escaped inside single quotes, so it is emitted as '\'' - closing the quoted run,
+     * appending an escaped quote, then reopening it.
+     *
+     * Always use this for any value that ends up in a command line, especially when the command
+     * runs as root. Values reachable from the UI (folder paths, custom environment variables) are
+     * otherwise evaluated by the shell.
+     */
+    public static String shellQuote(String s) {
+        if (s == null) {
+            return "''";
+        }
+        return "'" + s.replace("'", "'\\''") + "'";
+    }
+
+    /**
+     * Returns whether the given name is a valid POSIX shell variable name, i.e. matches
+     * [A-Za-z_][A-Za-z0-9_]*
+     *
+     * The name side of an "export NAME=value" statement cannot be quoted - it has to be a bare
+     * identifier - so unlike the value it cannot be made safe by escaping. It must be rejected
+     * instead, otherwise a crafted name injects additional shell commands.
+     */
+    public static boolean isValidEnvVarName(String name) {
+        if (TextUtils.isEmpty(name)) {
+            return false;
+        }
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            boolean isAlpha = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
+            if (isAlpha) {
+                continue;
+            }
+            if (i > 0 && c >= '0' && c <= '9') {
+                continue;
+            }
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
# Description

### Problem

`SyncthingRunnable.setupAndLaunch()` builds the root shell's command line
by string interpolation, unquoted:

```java
suOut.writeBytes(String.format("export %s=\"%s\"\n", entry.getKey(), entry.getValue()));
...
suOut.writeBytes("exec " + TextUtils.join(" ", mCommand) + "\n");
```

The environment can contain user-supplied entries from
**Settings → Troubleshooting → Environment variables**, and that field's
validator only checks that each space-separated token contains an `=`. It
does not reject shell metacharacters.

### Reproduction

Set `TESTVAR=$(id)` as an environment variable and read the launched
process's real environment:

```
adb shell su -c 'tr "\0" "\n" < /proc/$(pgrep -f libsyncthingnative)/environ' | grep TESTVAR
```

| Root mode | Result |
|---|---|
| off | `TESTVAR=$(id)` — literal, correct |
| **on** | `TESTVAR=uid=0(root) gid=0(root) groups=0(root) context=u:r:magisk:s0` |

With root enabled the shell **evaluated the substitution as root**. A value
containing a double quote (`TESTVAR=a"b`) unbalanced the quoting and stopped
Syncthing starting at all.


# Changes

- `Util.shellQuote()` — wraps a value in single quotes, emitting an embedded
  quote as `'\''`. Inside single quotes the shell performs no expansion, so
  `$`, backticks, `"` and `\` pass through literally. Applied to every
  environment value and every `argv` element in the `exec` line.
- Same quoting for the paths in `nativeBinaryCanWriteToPath()` and
  `fixAppDataPermissions()` — both build root command lines, and the former
  interpolates a folder path the user picked.
- `Util.isValidEnvVarName()` — an `export` target must be a bare identifier
  and therefore cannot be quoted, so names that are not valid shell
  identifiers are skipped with a warning. Otherwise `FOO;command=x` injects
  no matter how carefully the value is quoted.
